### PR TITLE
Remove deps from crate documentation

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -40,3 +40,7 @@ need_stdout = true
 command = ["cargo", "doc", "--color", "always"]
 need_stdout = true
 
+[jobs.doc-no-deps]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = true
+


### PR DESCRIPTION
Using --no-deps will remoe all transient deps in the documentation which will prevent to overload it.