### PR TITLE
Clean up object IDs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -7,7 +7,6 @@
 
 use core::hint::unreachable_unchecked;
 use core::time::Duration;
-use crate::config;
 use crate::types::*;
 
 #[macro_use]
@@ -26,7 +25,7 @@ generate_enums! {
     ////////////
 
     Agree: 1
-    CreateObject: 2
+    // CreateObject: 2
     // TODO: why do Decrypt and DeriveKey both have discriminant 3?!
     Decrypt: 3
     DeriveKey: 4
@@ -36,7 +35,7 @@ generate_enums! {
     DeleteAllKeys: 25
     Exists: 8
     // DeriveKeypair: 3
-    FindObjects: 9
+    // FindObjects: 9
     GenerateKey: 10
     GenerateSecretKey: 11
     // GenerateKeypair: 6
@@ -110,34 +109,34 @@ pub mod request {
     impl_request! {
         Agree:
             - mechanism: Mechanism
-            - private_key: ObjectHandle
-            - public_key: ObjectHandle
+            - private_key: KeyId
+            - public_key: KeyId
             - attributes: StorageAttributes
 
         Attest:
             // only Ed255 + P256
             - signing_mechanism: Mechanism
             // only Ed255 + P256
-            - private_key: ObjectHandle
+            - private_key: KeyId
 
-        // examples:
-        // - store public keys from external source
-        // - store certificates
-        CreateObject:
-            - attributes: Attributes
+        // // examples:
+        // // - store public keys from external source
+        // // - store certificates
+        // CreateObject:
+        //     - attributes: Attributes
 
         DebugDumpStore:
 
         Decrypt:
           - mechanism: Mechanism
-          - key: ObjectHandle
+          - key: KeyId
           - message: Message
           - associated_data: Message
           - nonce: ShortData
           - tag: ShortData
 
         Delete:
-          - key: ObjectHandle
+          - key: KeyId
 
         DeleteAllKeys:
           - location: Location
@@ -152,7 +151,7 @@ pub mod request {
         // - hierarchical deterministic wallet stuff
         DeriveKey:
             - mechanism: Mechanism
-            - base_key: ObjectHandle
+            - base_key: KeyId
             // - auxiliary_key: Option<ObjectHandle>
             - additional_data: Option<MediumData>
             // - attributes: KeyAttributes
@@ -172,17 +171,17 @@ pub mod request {
 
         Encrypt:
           - mechanism: Mechanism
-          - key: ObjectHandle
+          - key: KeyId
           - message: Message
           - associated_data: ShortData
           - nonce: Option<ShortData>
 
         Exists:
           - mechanism: Mechanism
-          - key: ObjectHandle
+          - key: KeyId
 
-        FindObjects:
-            // - attributes: Attributes
+        // FindObjects:
+        //     // - attributes: Attributes
 
         GenerateKey:
             - mechanism: Mechanism        // -> implies key type
@@ -253,12 +252,12 @@ pub mod request {
 
         SerializeKey:
           - mechanism: Mechanism
-          - key: ObjectHandle
+          - key: KeyId
           - format: KeySerialization
 
         Sign:
           - mechanism: Mechanism
-          - key: ObjectHandle
+          - key: KeyId
           - message: Message
           - format: SignatureSerialization
 
@@ -279,14 +278,14 @@ pub mod request {
 
         UnwrapKey:
           - mechanism: Mechanism
-          - wrapping_key: ObjectHandle
+          - wrapping_key: KeyId
           - wrapped_key: Message
           - associated_data: Message
           - attributes: StorageAttributes
 
         Verify:
           - mechanism: Mechanism
-          - key: ObjectHandle
+          - key: KeyId
           - message: Message
           - signature: Signature
           - format: SignatureSerialization
@@ -294,8 +293,8 @@ pub mod request {
         // this should always be an AEAD algorithm
         WrapKey:
           - mechanism: Mechanism
-          - wrapping_key: ObjectHandle
-          - key: ObjectHandle
+          - wrapping_key: KeyId
+          - key: KeyId
           - associated_data: Message
 
         RequestUserConsent:
@@ -311,13 +310,13 @@ pub mod request {
           - location: Location
 
         IncrementCounter:
-          - id: Id
+          - id: CounterId
 
         DeleteCertificate:
-          - id: Id
+          - id: CertId
 
         ReadCertificate:
-          - id: Id
+          - id: CertId
 
         WriteCertificate:
           - location: Location
@@ -337,18 +336,18 @@ pub mod reply {
         // e.g.: P256Raw -> SharedSecret32
         //       P256Sha256 -> SymmetricKey32
         Agree:
-            - shared_secret: ObjectHandle
+            - shared_secret: KeyId
 
         Attest:
-            - certificate: Id
+            - certificate: CertId
 
-        CreateObject:
-            - object: ObjectHandle
+        // CreateObject:
+        //     - object: ObjectHandle
 
-        FindObjects:
-            - objects: Vec<ObjectHandle, config::MAX_OBJECT_HANDLES>
-            // can be higher than capacity of vector
-            - num_objects: usize
+        // FindObjects:
+        //     - objects: Vec<ObjectHandle, config::MAX_OBJECT_HANDLES>
+        //     // can be higher than capacity of vector
+        //     - num_objects: usize
 
         DebugDumpStore:
 
@@ -362,14 +361,14 @@ pub mod reply {
             - count: usize
 
         DeriveKey:
-            - key: ObjectHandle
+            - key: KeyId
 
         // DeriveKeypair:
         //     - private_key: ObjectHandle
         //     - public_key: ObjectHandle
 
         DeserializeKey:
-            - key: ObjectHandle
+            - key: KeyId
 
 		Encrypt:
             - ciphertext: Message
@@ -380,14 +379,14 @@ pub mod reply {
             - exists: bool
 
         GenerateKey:
-            - key: ObjectHandle
+            - key: KeyId
 
         GenerateSecretKey:
-            - key: ObjectHandle
+            - key: KeyId
 
         // GenerateKeypair:
-        //     - private_key: ObjectHandle
-        //     - public_key: ObjectHandle
+        //     - private_key: KeyId
+        //     - public_key: KeyId
 
         Hash:
           - hash: ShortData
@@ -435,13 +434,13 @@ pub mod reply {
             - valid: bool
 
         UnsafeInjectKey:
-            - key: ObjectHandle
+            - key: KeyId
 
         UnsafeInjectSharedKey:
-            - key: ObjectHandle
+            - key: KeyId
 
         UnwrapKey:
-            - key: Option<ObjectHandle>
+            - key: Option<KeyId>
 
         WrapKey:
             - wrapped_key: Message
@@ -456,7 +455,7 @@ pub mod reply {
           - uptime: Duration
 
         CreateCounter:
-          - id: Id
+          - id: CounterId
 
         IncrementCounter:
           - counter: u128
@@ -467,7 +466,7 @@ pub mod reply {
           - der: Message
 
         WriteCertificate:
-          - id: Id
+          - id: CertId
     }
 
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@
 //! // use trussed::Client as _;
 //! fn sign<'c>(&'c mut self,
 //!   mechanism: Mechanism,
-//!   key: ObjectHandle,
+//!   key: KeyId,
 //!   data: &[u8],
 //!   format: SignatureSerialization
 //! ) -> ClientResult<'c, reply::Sign, Self>;
@@ -25,7 +25,7 @@
 //! `Ed255`, which also specializes the mechanism, e.g.
 //! ```ignore
 //! // use trussed::client::Ed255 as _;
-//! fn sign_ed255<'c>(&'c mut self, key: &ObjectHandle, message: &[u8])
+//! fn sign_ed255<'c>(&'c mut self, key: &KeyId, message: &[u8])
 //!   -> ClientResult<'c, reply::Sign, Self>
 //! ```
 //!
@@ -235,7 +235,7 @@ impl<S: Syscall> UiClient for ClientImplementation<S> {}
 /// Read/Write + Delete certificates
 pub trait CertificateClient: PollClient {
 
-    fn delete_certificate(&mut self, id: Id)
+    fn delete_certificate(&mut self, id: CertId)
         -> ClientResult<'_, reply::DeleteCertificate, Self>
     {
         let r = self.request(request::DeleteCertificate { id })?;
@@ -243,7 +243,7 @@ pub trait CertificateClient: PollClient {
         Ok(r)
     }
 
-    fn read_certificate(&mut self, id: Id)
+    fn read_certificate(&mut self, id: CertId)
         -> ClientResult<'_, reply::ReadCertificate, Self>
     {
         let r = self.request(request::ReadCertificate { id })?;
@@ -274,7 +274,7 @@ pub trait CryptoClient: PollClient {
 
     fn agree(
         &mut self, mechanism: Mechanism,
-        private_key: ObjectHandle, public_key: ObjectHandle,
+        private_key: KeyId, public_key: KeyId,
         attributes: StorageAttributes,
         )
         -> ClientResult<'_, reply::Agree, Self>
@@ -289,7 +289,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn attest(&mut self, signing_mechanism: Mechanism, private_key: ObjectHandle)
+    fn attest(&mut self, signing_mechanism: Mechanism, private_key: KeyId)
         -> ClientResult<'_, reply::Attest, Self>
     {
         let r = self.request(request::Attest {
@@ -300,7 +300,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn decrypt<'c>(&'c mut self, mechanism: Mechanism, key: ObjectHandle,
+    fn decrypt<'c>(&'c mut self, mechanism: Mechanism, key: KeyId,
                        message: &[u8], associated_data: &[u8],
                        nonce: &[u8], tag: &[u8],
                        )
@@ -315,7 +315,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn delete(&mut self, key: ObjectHandle)
+    fn delete(&mut self, key: KeyId)
         -> ClientResult<'_, reply::Delete, Self>
     {
         let r = self.request(request::Delete {
@@ -335,7 +335,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn derive_key(&mut self, mechanism: Mechanism, base_key: ObjectHandle, additional_data: Option<MediumData>, attributes: StorageAttributes)
+    fn derive_key(&mut self, mechanism: Mechanism, base_key: KeyId, additional_data: Option<MediumData>, attributes: StorageAttributes)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         let r = self.request(request::DeriveKey {
@@ -360,7 +360,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn encrypt<'c>(&'c mut self, mechanism: Mechanism, key: ObjectHandle,
+    fn encrypt<'c>(&'c mut self, mechanism: Mechanism, key: KeyId,
                        message: &[u8], associated_data: &[u8], nonce: Option<ShortData>)
         -> ClientResult<'c, reply::Encrypt, Self>
     {
@@ -371,7 +371,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn exists(&mut self, mechanism: Mechanism, key: ObjectHandle)
+    fn exists(&mut self, mechanism: Mechanism, key: KeyId)
         -> ClientResult<'_, reply::Exists, Self>
     {
         let r = self.request(request::Exists {
@@ -420,7 +420,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn serialize_key(&mut self, mechanism: Mechanism, key: ObjectHandle, format: KeySerialization)
+    fn serialize_key(&mut self, mechanism: Mechanism, key: KeyId, format: KeySerialization)
         -> ClientResult<'_, reply::SerializeKey, Self>
     {
         let r = self.request(request::SerializeKey {
@@ -435,7 +435,7 @@ pub trait CryptoClient: PollClient {
     fn sign<'c>(
         &'c mut self,
         mechanism: Mechanism,
-        key: ObjectHandle,
+        key: KeyId,
         data: &[u8],
         format: SignatureSerialization,
     )
@@ -454,7 +454,7 @@ pub trait CryptoClient: PollClient {
     fn verify<'c>(
         &'c mut self,
         mechanism: Mechanism,
-        key: ObjectHandle,
+        key: KeyId,
         message: &[u8],
         signature: &[u8],
         format: SignatureSerialization,
@@ -502,7 +502,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn unwrap_key<'c>(&'c mut self, mechanism: Mechanism, wrapping_key: ObjectHandle, wrapped_key: Message,
+    fn unwrap_key<'c>(&'c mut self, mechanism: Mechanism, wrapping_key: KeyId, wrapped_key: Message,
                        associated_data: &[u8], attributes: StorageAttributes)
         -> ClientResult<'c, reply::UnwrapKey, Self>
     {
@@ -518,7 +518,7 @@ pub trait CryptoClient: PollClient {
         Ok(r)
     }
 
-    fn wrap_key(&mut self, mechanism: Mechanism, wrapping_key: ObjectHandle, key: ObjectHandle,
+    fn wrap_key(&mut self, mechanism: Mechanism, wrapping_key: KeyId, key: KeyId,
                        associated_data: &[u8])
         -> ClientResult<'_, reply::WrapKey, Self>
     {
@@ -541,7 +541,7 @@ pub trait CounterClient: PollClient {
         Ok(r)
     }
 
-    fn increment_counter(&mut self, id: Id)
+    fn increment_counter(&mut self, id: CounterId)
         -> ClientResult<'_, reply::IncrementCounter, Self>
     {
         let r = self.request(request::IncrementCounter { id })?;

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -4,7 +4,7 @@ use super::*;
 impl<S: Syscall> Aes256Cbc for ClientImplementation<S> {}
 
 pub trait Aes256Cbc: CryptoClient {
-    fn decrypt_aes256cbc<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn decrypt_aes256cbc<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Decrypt, Self>
     {
         self.decrypt(
@@ -12,7 +12,7 @@ pub trait Aes256Cbc: CryptoClient {
         )
     }
 
-    fn wrap_key_aes256cbc(&mut self, wrapping_key: ObjectHandle, key: ObjectHandle)
+    fn wrap_key_aes256cbc(&mut self, wrapping_key: KeyId, key: KeyId)
         -> ClientResult<'_, reply::WrapKey, Self>
     {
         self.wrap_key(Mechanism::Aes256Cbc, wrapping_key, key, &[])
@@ -23,14 +23,14 @@ pub trait Aes256Cbc: CryptoClient {
 impl<S: Syscall> Chacha8Poly1305 for ClientImplementation<S> {}
 
 pub trait Chacha8Poly1305: CryptoClient {
-    fn decrypt_chacha8poly1305<'c>(&'c mut self, key: ObjectHandle, message: &[u8], associated_data: &[u8],
+    fn decrypt_chacha8poly1305<'c>(&'c mut self, key: KeyId, message: &[u8], associated_data: &[u8],
                                        nonce: &[u8], tag: &[u8])
         -> ClientResult<'c, reply::Decrypt, Self>
     {
         self.decrypt(Mechanism::Chacha8Poly1305, key, message, associated_data, nonce, tag)
     }
 
-    fn encrypt_chacha8poly1305<'c>(&'c mut self, key: ObjectHandle, message: &[u8], associated_data: &[u8],
+    fn encrypt_chacha8poly1305<'c>(&'c mut self, key: KeyId, message: &[u8], associated_data: &[u8],
                                        nonce: Option<&[u8; 12]>)
         -> ClientResult<'c, reply::Encrypt, Self>
     {
@@ -44,7 +44,7 @@ pub trait Chacha8Poly1305: CryptoClient {
         self.generate_key(Mechanism::Chacha8Poly1305, StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn unwrap_key_chacha8poly1305<'c>(&'c mut self, wrapping_key: ObjectHandle, wrapped_key: &[u8],
+    fn unwrap_key_chacha8poly1305<'c>(&'c mut self, wrapping_key: KeyId, wrapped_key: &[u8],
                        associated_data: &[u8], location: Location)
         -> ClientResult<'c, reply::UnwrapKey, Self>
     {
@@ -54,7 +54,7 @@ pub trait Chacha8Poly1305: CryptoClient {
                         StorageAttributes::new().set_persistence(location))
     }
 
-    fn wrap_key_chacha8poly1305<'c>(&'c mut self, wrapping_key: ObjectHandle, key: ObjectHandle,
+    fn wrap_key_chacha8poly1305<'c>(&'c mut self, wrapping_key: KeyId, key: KeyId,
                        associated_data: &[u8])
         -> ClientResult<'c, reply::WrapKey, Self>
     {
@@ -66,7 +66,7 @@ pub trait Chacha8Poly1305: CryptoClient {
 impl<S: Syscall> HmacBlake2s for ClientImplementation<S> {}
 
 pub trait HmacBlake2s: CryptoClient {
-    fn hmacblake2s_derive_key(&mut self, base_key: ObjectHandle, message: &[u8], persistence: Location)
+    fn hmacblake2s_derive_key(&mut self, base_key: KeyId, message: &[u8], persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(
@@ -75,7 +75,7 @@ pub trait HmacBlake2s: CryptoClient {
             StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn sign_hmacblake2s<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn sign_hmacblake2s<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Sign, Self>
     {
         self.sign(Mechanism::HmacBlake2s, key, message, SignatureSerialization::Raw)
@@ -87,7 +87,7 @@ pub trait HmacBlake2s: CryptoClient {
 impl<S: Syscall> HmacSha1 for ClientImplementation<S> {}
 
 pub trait HmacSha1: CryptoClient {
-    fn hmacsha1_derive_key(&mut self, base_key: ObjectHandle, message: &[u8], persistence: Location)
+    fn hmacsha1_derive_key(&mut self, base_key: KeyId, message: &[u8], persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(
@@ -96,7 +96,7 @@ pub trait HmacSha1: CryptoClient {
             StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn sign_hmacsha1<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn sign_hmacsha1<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Sign, Self>
     {
         self.sign(Mechanism::HmacSha1, key, message, SignatureSerialization::Raw)
@@ -108,7 +108,7 @@ pub trait HmacSha1: CryptoClient {
 impl<S: Syscall> HmacSha256 for ClientImplementation<S> {}
 
 pub trait HmacSha256: CryptoClient {
-    fn hmacsha256_derive_key(&mut self, base_key: ObjectHandle, message: &[u8], persistence: Location)
+    fn hmacsha256_derive_key(&mut self, base_key: KeyId, message: &[u8], persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(
@@ -117,7 +117,7 @@ pub trait HmacSha256: CryptoClient {
             StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn sign_hmacsha256<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn sign_hmacsha256<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Sign, Self>
     {
         self.sign(Mechanism::HmacSha256, key, message, SignatureSerialization::Raw)
@@ -129,7 +129,7 @@ pub trait HmacSha256: CryptoClient {
 impl<S: Syscall> HmacSha512 for ClientImplementation<S> {}
 
 pub trait HmacSha512: CryptoClient {
-    fn hmacsha512_derive_key(&mut self, base_key: ObjectHandle, message: &[u8], persistence: Location)
+    fn hmacsha512_derive_key(&mut self, base_key: KeyId, message: &[u8], persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(
@@ -138,7 +138,7 @@ pub trait HmacSha512: CryptoClient {
             StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn sign_hmacsha512<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn sign_hmacsha512<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Sign, Self>
     {
         self.sign(Mechanism::HmacSha512, key, message, SignatureSerialization::Raw)
@@ -156,7 +156,7 @@ pub trait Ed255: CryptoClient {
         self.generate_key(Mechanism::Ed255, StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn derive_ed255_public_key(&mut self, private_key: ObjectHandle, persistence: Location)
+    fn derive_ed255_public_key(&mut self, private_key: KeyId, persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(Mechanism::Ed255, private_key, None, StorageAttributes::new().set_persistence(persistence))
@@ -168,19 +168,19 @@ pub trait Ed255: CryptoClient {
         self.deserialize_key(Mechanism::Ed255, serialized_key, format, attributes)
     }
 
-    fn serialize_ed255_key(&mut self, key: ObjectHandle, format: KeySerialization)
+    fn serialize_ed255_key(&mut self, key: KeyId, format: KeySerialization)
         -> ClientResult<'_, reply::SerializeKey, Self>
     {
         self.serialize_key(Mechanism::Ed255, key, format)
     }
 
-    fn sign_ed255<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn sign_ed255<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Sign, Self>
     {
         self.sign(Mechanism::Ed255, key, message, SignatureSerialization::Raw)
     }
 
-    fn verify_ed255<'c>(&'c mut self, key: ObjectHandle, message: &[u8], signature: &[u8])
+    fn verify_ed255<'c>(&'c mut self, key: KeyId, message: &[u8], signature: &[u8])
         -> ClientResult<'c, reply::Verify, Self>
     {
         self.verify(Mechanism::Ed255, key, message, signature, SignatureSerialization::Raw)
@@ -197,7 +197,7 @@ pub trait P256: CryptoClient {
         self.generate_key(Mechanism::P256, StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn derive_p256_public_key(&mut self, private_key: ObjectHandle, persistence: Location)
+    fn derive_p256_public_key(&mut self, private_key: KeyId, persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(Mechanism::P256, private_key, None, StorageAttributes::new().set_persistence(persistence))
@@ -209,7 +209,7 @@ pub trait P256: CryptoClient {
         self.deserialize_key(Mechanism::P256, serialized_key, format, attributes)
     }
 
-    fn serialize_p256_key(&mut self, key: ObjectHandle, format: KeySerialization)
+    fn serialize_p256_key(&mut self, key: KeyId, format: KeySerialization)
         -> ClientResult<'_, reply::SerializeKey, Self>
     {
         self.serialize_key(Mechanism::P256, key, format)
@@ -221,19 +221,19 @@ pub trait P256: CryptoClient {
     //
     // on the other hand: if users need sha256, then if the service runs in secure trustzone
     // domain, we'll maybe need two copies of the sha2 code
-    fn sign_p256<'c>(&'c mut self, key: ObjectHandle, message: &[u8], format: SignatureSerialization)
+    fn sign_p256<'c>(&'c mut self, key: KeyId, message: &[u8], format: SignatureSerialization)
         -> ClientResult<'c, reply::Sign, Self>
     {
         self.sign(Mechanism::P256, key, message, format)
     }
 
-    fn verify_p256<'c>(&'c mut self, key: ObjectHandle, message: &[u8], signature: &[u8])
+    fn verify_p256<'c>(&'c mut self, key: KeyId, message: &[u8], signature: &[u8])
         -> ClientResult<'c, reply::Verify, Self>
     {
         self.verify(Mechanism::P256, key, message, signature, SignatureSerialization::Raw)
     }
 
-    fn agree_p256(&mut self, private_key: ObjectHandle, public_key: ObjectHandle, persistence: Location)
+    fn agree_p256(&mut self, private_key: KeyId, public_key: KeyId, persistence: Location)
         -> ClientResult<'_, reply::Agree, Self>
     {
         self.agree(
@@ -249,7 +249,7 @@ pub trait P256: CryptoClient {
 impl<S: Syscall> Sha256 for ClientImplementation<S> {}
 
 pub trait Sha256: CryptoClient {
-    fn sha256_derive_key(&mut self, shared_key: ObjectHandle, persistence: Location)
+    fn sha256_derive_key(&mut self, shared_key: KeyId, persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(Mechanism::Sha256, shared_key, None, StorageAttributes::new().set_persistence(persistence))
@@ -266,13 +266,13 @@ pub trait Sha256: CryptoClient {
 impl<S: Syscall> Tdes for ClientImplementation<S> {}
 
 pub trait Tdes: CryptoClient {
-    fn decrypt_tdes<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn decrypt_tdes<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Decrypt, Self>
     {
         self.decrypt(Mechanism::Tdes, key, message, &[], &[], &[])
     }
 
-    fn encrypt_tdes<'c>(&'c mut self, key: ObjectHandle, message: &[u8])
+    fn encrypt_tdes<'c>(&'c mut self, key: KeyId, message: &[u8])
         -> ClientResult<'c, reply::Encrypt, Self>
     {
         self.encrypt(Mechanism::Tdes, key, message, &[], None)
@@ -283,7 +283,7 @@ pub trait Tdes: CryptoClient {
 impl<S: Syscall> Totp for ClientImplementation<S> {}
 
 pub trait Totp: CryptoClient {
-    fn sign_totp(&mut self, key: ObjectHandle, timestamp: u64)
+    fn sign_totp(&mut self, key: KeyId, timestamp: u64)
         -> ClientResult<'_, reply::Sign, Self>
     {
         self.sign(Mechanism::Totp, key,
@@ -303,13 +303,13 @@ pub trait X255: CryptoClient {
         self.generate_key(Mechanism::X255, StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn derive_x255_public_key(&mut self, secret_key: ObjectHandle, persistence: Location)
+    fn derive_x255_public_key(&mut self, secret_key: KeyId, persistence: Location)
         -> ClientResult<'_, reply::DeriveKey, Self>
     {
         self.derive_key(Mechanism::X255, secret_key, None, StorageAttributes::new().set_persistence(persistence))
     }
 
-    fn agree_x255(&mut self, private_key: ObjectHandle, public_key: ObjectHandle, persistence: Location)
+    fn agree_x255(&mut self, private_key: KeyId, public_key: KeyId, persistence: Location)
         -> ClientResult<'_, reply::Agree, Self>
     {
         self.agree(

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -21,7 +21,7 @@ impl Encrypt for super::Aes256Cbc
         // TODO: perhaps use NoPadding and have client pad, to emphasize spec-conformance?
         type Aes256Cbc = Cbc<Aes256, ZeroPadding>;
 
-        let key_id = request.key.object_id;
+        let key_id = request.key;
         // let mut symmetric_key = [0u8; 32];
         // let path = keystore.key_path(key::Secrecy::Secret, &key_id);
         // keystore.load_key(&path, key::Kind::SymmetricKey32, &mut symmetric_key)?;
@@ -59,13 +59,13 @@ impl WrapKey for super::Aes256Cbc
         -> Result<reply::WrapKey, Error>
     {
         // TODO: need to check both secret and private keys
-        // let path = keystore.key_path(key::Secrecy::Secret, &request.key.object_id)?;
+        // let path = keystore.key_path(key::Secrecy::Secret, &request.key)?;
         // let (serialized_key, _location) = keystore.load_key_unchecked(&path)?;
 
         // let message: Message = serialized_key.material.try_to_byte_buf().map_err(|_| Error::InternalError)?;
 
         let message: Message = crate::Bytes::try_from_slice(keystore
-            .load_key(key::Secrecy::Secret, None, &request.key.object_id)?
+            .load_key(key::Secrecy::Secret, None, &request.key)?
             .material.as_ref()).map_err(|_| Error::InternalError)?;
 
         let encryption_request = request::Encrypt {
@@ -97,7 +97,7 @@ impl Decrypt for super::Aes256Cbc
         // TODO: perhaps use NoPadding and have client pad, to emphasize spec-conformance?
         type Aes256Cbc = Cbc<Aes256, ZeroPadding>;
 
-        let key_id = request.key.object_id;
+        let key_id = request.key;
         let symmetric_key: [u8; 32] = keystore
             .load_key(key::Secrecy::Secret, None, &key_id)?
             .material.as_ref()

--- a/src/mechanisms/hmacsha1.rs
+++ b/src/mechanisms/hmacsha1.rs
@@ -15,7 +15,7 @@ impl DeriveKey for super::HmacSha1
         use hmac::{Hmac, Mac, NewMac};
         type HmacSha1 = Hmac<sha1::Sha1>;
 
-        let key_id = request.base_key.object_id;
+        let key_id = request.base_key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
         let mut mac = HmacSha1::new_from_slice(&shared_secret.as_ref())
@@ -30,7 +30,7 @@ impl DeriveKey for super::HmacSha1
             key::Secrecy::Secret, key::Kind::Symmetric(20),
             &derived_key)?;
 
-        Ok(reply::DeriveKey { key: ObjectHandle { object_id: key_id } })
+        Ok(reply::DeriveKey { key: key_id })
 
     }
 }
@@ -46,7 +46,7 @@ impl Sign for super::HmacSha1
         use hmac::{Hmac, Mac, NewMac};
         type HmacSha1 = Hmac<Sha1>;
 
-        let key_id = request.key.object_id;
+        let key_id = request.key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
         let mut mac = HmacSha1::new_from_slice(&shared_secret.as_ref())

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -15,7 +15,7 @@ impl DeriveKey for super::HmacSha256
         use hmac::{Hmac, Mac, NewMac};
         type HmacSha256 = Hmac<sha2::Sha256>;
 
-        let key_id = request.base_key.object_id;
+        let key_id = request.base_key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
         let mut mac = HmacSha256::new_from_slice(&shared_secret.as_ref())
@@ -30,7 +30,7 @@ impl DeriveKey for super::HmacSha256
             key::Secrecy::Secret, key::Kind::Symmetric(32),
             &derived_key)?;
 
-        Ok(reply::DeriveKey { key: ObjectHandle { object_id: key_id } })
+        Ok(reply::DeriveKey { key: key_id })
 
     }
 }
@@ -46,7 +46,7 @@ impl Sign for super::HmacSha256
         use hmac::{Hmac, Mac, NewMac};
         type HmacSha256 = Hmac<Sha256>;
 
-        let key_id = request.key.object_id;
+        let key_id = request.key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
         let mut mac = HmacSha256::new_from_slice(&shared_secret.as_ref())

--- a/src/mechanisms/sha256.rs
+++ b/src/mechanisms/sha256.rs
@@ -10,7 +10,7 @@ impl DeriveKey for super::Sha256
     fn derive_key(keystore: &mut impl Keystore, request: &request::DeriveKey)
         -> Result<reply::DeriveKey, Error>
     {
-        let base_id = &request.base_key.object_id;
+        let base_id = &request.base_key;
 
         let shared_secret = keystore
             .load_key(key::Secrecy::Secret, None, base_id)?
@@ -27,9 +27,7 @@ impl DeriveKey for super::Sha256
             key::Secrecy::Secret, key::Kind::Symmetric(32),
             &symmetric_key)?;
 
-        Ok(reply::DeriveKey {
-            key: ObjectHandle { object_id: key_id },
-        })
+        Ok(reply::DeriveKey { key: key_id })
     }
 }
 

--- a/src/mechanisms/tdes.rs
+++ b/src/mechanisms/tdes.rs
@@ -24,7 +24,7 @@ impl Encrypt for super::Tdes
     {
         if request.message.len() != 8 { return Err(Error::WrongMessageLength); }
 
-        let key_id = request.key.object_id;
+        let key_id = request.key;
 
         let symmetric_key: [u8; 24] = keystore
             .load_key(key::Secrecy::Secret, None, &key_id)?
@@ -50,7 +50,7 @@ impl Decrypt for super::Tdes
     {
         if request.message.len() != 8 { return Err(Error::WrongMessageLength); }
 
-        let key_id = request.key.object_id;
+        let key_id = request.key;
 
         let symmetric_key: [u8; 24] = keystore
             .load_key(key::Secrecy::Secret, None, &key_id)?

--- a/src/mechanisms/totp.rs
+++ b/src/mechanisms/totp.rs
@@ -50,7 +50,7 @@ impl Sign for super::Totp
     fn sign(keystore: &mut impl Keystore, request: &request::Sign)
         -> Result<reply::Sign, Error>
     {
-        let key_id = request.key.object_id;
+        let key_id = request.key;
 
         let secret = keystore
             .load_key(key::Secrecy::Secret, None, &key_id)?
@@ -75,7 +75,7 @@ impl Exists for super::Totp
     fn exists(keystore: &mut impl Keystore, request: &request::Exists)
         -> Result<reply::Exists, Error>
     {
-        let key_id = request.key.object_id;
+        let key_id = request.key;
 
         let exists = keystore.exists_key(key::Secrecy::Secret, Some(key::Kind::Symmetric(20)), &key_id);
         Ok(reply::Exists { exists })

--- a/src/mechanisms/trng.rs
+++ b/src/mechanisms/trng.rs
@@ -1,8 +1,6 @@
 use crate::api::*;
-// use crate::config::*;
 use crate::error::Error;
 use crate::service::*;
-use crate::types::*;
 
 #[cfg(feature = "trng")]
 impl GenerateKey for super::Trng
@@ -12,7 +10,7 @@ impl GenerateKey for super::Trng
     {
         // generate entropy
         let mut entropy = [0u8; 32];
-        keystore.drbg().fill_bytes(&mut entropy);
+        keystore.rng().fill_bytes(&mut entropy);
 
         // store keys
         let key_id = keystore.store_key(
@@ -21,7 +19,7 @@ impl GenerateKey for super::Trng
             key::Kind::Symmetric(32),
             &entropy)?;
 
-        Ok(reply::GenerateKey { key: ObjectHandle { object_id: key_id } })
+        Ok(reply::GenerateKey { key: key_id })
     }
 }
 

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -1,38 +1,33 @@
-use core::fmt::Write;
-
+use chacha20::ChaCha8Rng;
 use littlefs2::path::PathBuf;
 
 use crate::{
-    Bytes,
-    consts,
     error::{Error, Result},
     store::{self, Store},
-    types::{ClientId, Id, Location, Message},
+    types::{CertId, ClientId, Location, Message},
 };
-
-use super::counterstore::Counterstore;
-
 
 pub struct ClientCertstore<S>
 where
     S: Store,
 {
     client_id: ClientId,
+    rng: ChaCha8Rng,
     store: S,
 }
 
 pub trait Certstore {
-    fn delete_certificate(&mut self, id: Id) -> Result<()>;
-    fn read_certificate(&mut self, id: Id) -> Result<Message>;
+    fn delete_certificate(&mut self, id: CertId) -> Result<()>;
+    fn read_certificate(&mut self, id: CertId) -> Result<Message>;
     /// TODO: feels a bit heavy-weight to pass in the ClientCounterstore here
     /// just to ensure the next global counter ("counter zero") is used, and
     /// not something random.
-    fn write_certificate(&mut self, location: Location, der: &Message, counterstore: &mut impl Counterstore) -> Result<Id>;
+    fn write_certificate(&mut self, location: Location, der: &Message) -> Result<CertId>;
 }
 
 impl<S: Store> Certstore for ClientCertstore<S> {
 
-    fn delete_certificate(&mut self, id: Id) -> Result<()> {
+    fn delete_certificate(&mut self, id: CertId) -> Result<()> {
         let path = self.cert_path(id);
         let locations = [
             Location::Internal,
@@ -44,7 +39,7 @@ impl<S: Store> Certstore for ClientCertstore<S> {
         }).then(|| ()).ok_or(Error::NoSuchKey)
     }
 
-    fn read_certificate(&mut self, id: Id) -> Result<Message> {
+    fn read_certificate(&mut self, id: CertId) -> Result<Message> {
         let path = self.cert_path(id);
         let locations = [
             Location::Internal,
@@ -56,8 +51,8 @@ impl<S: Store> Certstore for ClientCertstore<S> {
         }).ok_or(Error::NoSuchCertificate)
     }
 
-    fn write_certificate(&mut self, location: Location, der: &Message, counterstore: &mut impl Counterstore) -> Result<Id> {
-        let id = Id(counterstore.increment_counter_zero());
+    fn write_certificate(&mut self, location: Location, der: &Message) -> Result<CertId> {
+        let id = CertId::new(&mut self.rng);
         let path = self.cert_path(id);
         store::store(self.store, location, &path, &der.as_slice())?;
         Ok(id)
@@ -65,17 +60,15 @@ impl<S: Store> Certstore for ClientCertstore<S> {
 }
 
 impl<S: Store> ClientCertstore<S> {
-    pub fn new(client_id: ClientId, store: S) -> Self {
-        Self { client_id, store }
+    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: S) -> Self {
+        Self { client_id, rng, store }
     }
 
-    fn cert_path(&self, id: Id) -> PathBuf {
+    fn cert_path(&self, id: CertId) -> PathBuf {
         let mut path = PathBuf::new();
         path.push(&self.client_id);
         path.push(&PathBuf::from("x5c"));
-        let mut buf = Bytes::<consts::U32>::new();
-        write!(&mut buf, "{}", id.0).ok();
-        path.push(&PathBuf::from(buf.as_slice()));
+        path.push(&PathBuf::from(id.hex().as_ref()));
         path
     }
 

--- a/tests/counter.rs
+++ b/tests/counter.rs
@@ -2,65 +2,56 @@ mod client;
 mod store;
 
 use trussed::{
-    client::{
-        CounterClient as _,
-        // ManagementClient as _,
-    },
-    error::Result,
+    client::CounterClient as _,
     syscall,
     types::Location::*,
-    store::counterstore::{
-        Counterstore as _,
-        ClientCounterstore,
-    },
 };
 
-#[test]
-fn counter_implementation() {
-    let result: Result<()> = store::get(|store| {
+// #[test]
+// fn counter_implementation() {
+//     let result: Result<()> = store::get(|store| {
 
-        let client_id = "test".into();
-        let mut cstore = ClientCounterstore::new(client_id, *store);
+//         let client_id = "test".into();
+//         let mut cstore = ClientCounterstore::new(client_id, *store);
 
-        assert_eq!(cstore.increment_counter_zero(), 257);
-        assert_eq!(cstore.increment_counter_zero(), 258);
-        assert_eq!(cstore.increment_counter_zero(), 259);
+//         assert_eq!(cstore.increment_counter_zero(), 257);
+//         assert_eq!(cstore.increment_counter_zero(), 258);
+//         assert_eq!(cstore.increment_counter_zero(), 259);
 
-        let id = cstore.create(Volatile).unwrap();  // counter zero is now at 4
-        assert_eq!(cstore.increment_counter_zero(), 261);
+//         let id = cstore.create(Volatile).unwrap();  // counter zero is now at 4
+//         assert_eq!(cstore.increment_counter_zero(), 261);
 
-        assert_eq!(cstore.increment(id)?, 257);
-        assert_eq!(cstore.increment(id)?, 258);
-        assert_eq!(cstore.increment(id)?, 259);
+//         assert_eq!(cstore.increment(id)?, 257);
+//         assert_eq!(cstore.increment(id)?, 258);
+//         assert_eq!(cstore.increment(id)?, 259);
 
-        assert_eq!(cstore.increment_counter_zero(), 262);
-        Ok(())
-    });
-    result.unwrap();
-}
+//         assert_eq!(cstore.increment_counter_zero(), 262);
+//         Ok(())
+//     });
+//     result.unwrap();
+// }
 
 #[test]
 fn counter_client() {
     client::get(|client| {
+
         let id = syscall!(client.create_counter(Volatile)).id;
-        assert_eq!(syscall!(client.increment_counter(id)).counter, 257);
-        assert_eq!(syscall!(client.increment_counter(id)).counter, 258);
-        assert_eq!(syscall!(client.increment_counter(id)).counter, 259);
+        assert_eq!(syscall!(client.increment_counter(id)).counter, 0);
+        assert_eq!(syscall!(client.increment_counter(id)).counter, 1);
+        assert_eq!(syscall!(client.increment_counter(id)).counter, 2);
 
         let jd = syscall!(client.create_counter(External)).id;
-        assert_eq!(syscall!(client.increment_counter(jd)).counter, 257);
-        assert_eq!(syscall!(client.increment_counter(jd)).counter, 258);
+        assert_eq!(syscall!(client.increment_counter(jd)).counter, 0);
+        assert_eq!(syscall!(client.increment_counter(jd)).counter, 1);
 
-        assert_eq!(syscall!(client.increment_counter(id)).counter, 260);
+        assert_eq!(syscall!(client.increment_counter(id)).counter, 3);
 
-        for i in 5..1_000 {
-            assert_eq!(syscall!(client.increment_counter(id)).counter, 256 + i);
+        for i in 4..1_000 {
+            assert_eq!(syscall!(client.increment_counter(id)).counter, i);
         }
-        for j in 3..1_000 {
-            assert_eq!(syscall!(client.increment_counter(jd)).counter, 256 + j);
+        for j in 2..1_000 {
+            assert_eq!(syscall!(client.increment_counter(jd)).counter, j);
         }
-
-        // assert_eq!(syscall!(client.uptime()).uptime.as_nanos(), 10);
 
     });
 }

--- a/tests/store/mod.rs
+++ b/tests/store/mod.rs
@@ -13,6 +13,7 @@ trussed::store!(Store,
     Volatile: VolatileStorage
 );
 
+#[allow(dead_code)]
 pub fn get<R>(
         test: impl FnOnce(&mut Store) -> R
     )
@@ -22,6 +23,7 @@ pub fn get<R>(
     test(&mut store)
 }
 
+#[allow(dead_code)]
 fn init_store() -> Store {
     Store::format(
         InternalStorage::new(),


### PR DESCRIPTION
This cleans up the object ID handling, in particular the inconsistent use of random IDs and counters.

In brief, now:
- an "object ID" (types::Id) is a wrapper around a u128
- in most cases, these are generated randomly, using a `CryptoRng + RngCore` RNG
- low IDs (corresponding to u8) can be constructed directly (`::from_special`); this is used for keys and certs that are assumed to already exist on the file system (provisioned in factory or by developer), e.g. FIDO2 batch certificate + key
- the three current object classes (Keys, Certificates, Counters) have distinct corresponding KeyId, CertId, CounterId types as handles
- UniqueId and ObjectHandle are gone

This should have no breaking impact on data in the filesystem (with the adjustments for code easily performed) but add a bit of consistency and type safety.