### PR TITLE
Add UiClient::wink method

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -81,6 +81,7 @@ generate_enums! {
     RequestUserConsent: 41
     Reboot: 42
     Uptime: 43
+    Wink: 44
 
     //////////////
     // Counters //
@@ -306,6 +307,9 @@ pub mod request {
 
         Uptime:
 
+        Wink:
+          - duration: core::time::Duration
+
         CreateCounter:
           - location: Location
 
@@ -453,6 +457,8 @@ pub mod reply {
 
         Uptime:
           - uptime: Duration
+
+        Wink:
 
         CreateCounter:
           - id: CounterId

--- a/src/client.rs
+++ b/src/client.rs
@@ -703,6 +703,11 @@ pub trait UiClient: PollClient {
         Ok(r)
     }
 
+    fn wink(&mut self, duration: core::time::Duration) -> ClientResult<'_, reply::Wink, Self> {
+        let r = self.request(request::Wink { duration } )?;
+        r.client.syscall();
+        Ok(r)
+    }
 }
 
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -16,23 +16,36 @@ pub use crate::types::consent;
 pub trait UserInterface {
     /// Check if the user has indicated their presence so as to give
     /// consent to an action.
-    fn check_user_presence(&mut self) -> consent::Level;
+    fn check_user_presence(&mut self) -> consent::Level {
+        consent::Level::None
+    }
 
     /// Set the state of Trussed to give potential feedback to the user.
-    fn set_status(&mut self, status: ui::Status);
+    fn set_status(&mut self, status: ui::Status) {
+        let _ = status;
+    }
 
     /// May be called during idle periods to give the UI the opportunity to update.
-    fn refresh(&mut self);
+    fn refresh(&mut self) {}
 
     /// Return the duration since startup.
-    fn uptime(&mut self) -> core::time::Duration;
+    fn uptime(&mut self) -> core::time::Duration {
+        Default::default()
+    }
 
     /// Exit / reset the application
-    fn reboot (&mut self, to: reboot::To) -> !;
+    fn reboot (&mut self, to: reboot::To) -> ! {
+        let _ = to;
+        loop {
+            continue
+        }
+    }
 
     /// Trigger a visible or audible effect for the given duration that allows the user to identify
     /// the device.
-    fn wink(&mut self, duration: core::time::Duration);
+    fn wink(&mut self, duration: core::time::Duration) {
+        let _ = duration;
+    }
 }
 
 // This is the same trick as in "store.rs",

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -29,6 +29,10 @@ pub trait UserInterface {
 
     /// Exit / reset the application
     fn reboot (&mut self, to: reboot::To) -> !;
+
+    /// Trigger a visible or audible effect for the given duration that allows the user to identify
+    /// the device.
+    fn wink(&mut self, duration: core::time::Duration);
 }
 
 // This is the same trick as in "store.rs",

--- a/src/service.rs
+++ b/src/service.rs
@@ -526,6 +526,11 @@ impl<P: Platform> ServiceResources<P> {
                 Ok(Reply::Uptime(reply::Uptime { uptime: self.platform.user_interface().uptime() }))
             }
 
+            Request::Wink(request) => {
+                self.platform.user_interface().wink(request.duration);
+                Ok(Reply::Wink(reply::Wink {}))
+            }
+
             Request::CreateCounter(request) => {
                 counterstore.create(request.location)
                     .map(|id| Reply::CreateCounter(reply::CreateCounter { id } ))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -75,6 +75,8 @@ impl crate::platform::UserInterface for UserInterface
         std::process::exit(25);
     }
 
+    fn wink(&mut self, _duration: core::time::Duration) {}
+
 }
 
 const_ram_storage!(InternalStorage, 4096*10);

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -60,6 +60,7 @@ pub mod ui {
         fn refresh(&mut self) {}
         fn uptime(&mut self) -> core::time::Duration { self.start_time.elapsed() }
         fn reboot(&mut self, _to: reboot::To) -> ! { loop { continue; } }
+        fn wink(&mut self, _duration: core::time::Duration) {}
     }
 }
 


### PR DESCRIPTION
This patch adds the UiClient::wink method that triggers a visible or
audible response of the device, allowing the user to identify it.  This
is for example needed to implement the CTAPHID wink command.