### PR TITLE
Platform.status method

### DIFF
--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -38,7 +38,7 @@ impl GenerateKey for super::Chacha8Poly1305 {
     }
 }
 
-    #[inline(never)]
+#[inline(never)]
 fn increment_nonce(nonce: &mut [u8]) -> Result<(), Error> {
     let mut carry: u16 = 1;
     for digit in nonce.iter_mut() {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -25,6 +25,10 @@ pub trait UserInterface {
         let _ = status;
     }
 
+    fn status(&self) -> ui::Status {
+        ui::Status::Idle
+    }
+
     /// May be called during idle periods to give the UI the opportunity to update.
     fn refresh(&mut self) {}
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -451,6 +451,7 @@ pub fn create_directories<'s, S: LfsStorage>(
 }
 
 /// Reads contents from path in location of store.
+#[inline(never)]
 pub fn read<const N: usize>(store: impl Store, location: Location, path: &Path) -> Result<Bytes<N>, Error> {
     debug_now!("reading {}", &path);
     match location {
@@ -461,6 +462,7 @@ pub fn read<const N: usize>(store: impl Store, location: Location, path: &Path) 
 }
 
 /// Writes contents to path in location of store.
+#[inline(never)]
 pub fn write(store: impl Store, location: Location, path: &Path, contents: &[u8]) -> Result<(), Error> {
     debug_now!("writing {}", &path);
     match location {
@@ -471,6 +473,7 @@ pub fn write(store: impl Store, location: Location, path: &Path, contents: &[u8]
 }
 
 /// Creates parent directory if necessary, then writes.
+#[inline(never)]
 pub fn store(store: impl Store, location: Location, path: &Path, contents: &[u8]) -> Result<(), Error> {
     debug_now!("storing {}", &path);
     match location {
@@ -481,6 +484,7 @@ pub fn store(store: impl Store, location: Location, path: &Path, contents: &[u8]
     write(store, location, path, contents)
 }
 
+#[inline(never)]
 pub fn delete(store: impl Store, location: Location, path: &Path) -> bool {
     debug_now!("deleting {}", &path);
     let outcome = match location {
@@ -491,6 +495,7 @@ pub fn delete(store: impl Store, location: Location, path: &Path) -> bool {
     outcome.is_ok()
 }
 
+#[inline(never)]
 pub fn exists(store: impl Store, location: Location, path: &Path) -> bool {
     debug_now!("checking existence of {}", &path);
     match location {
@@ -500,6 +505,7 @@ pub fn exists(store: impl Store, location: Location, path: &Path) -> bool {
     }
 }
 
+#[inline(never)]
 pub fn remove_dir(store: impl Store, location: Location, path: &Path) -> bool {
     debug_now!("remove_dir'ing {}", &path);
     let outcome = match location {
@@ -510,6 +516,7 @@ pub fn remove_dir(store: impl Store, location: Location, path: &Path) -> bool {
     outcome.is_ok()
 }
 
+#[inline(never)]
 pub fn remove_dir_all_where<P>(store: impl Store, location: Location, path: &Path, predicate: P) -> Result<usize, Error>
 where
     P: Fn(&DirEntry) -> bool,


### PR DESCRIPTION
- add a `status(&Platform) -> ui::Status` method
- set status to `Processing` when processing
- sprinkle a bit more `#[inline(never)]` (it's cargo-cultish, but we seem to not have a better approach to controlling stack currently)