### PR TITLE
gh-act: build solo2/nk3-fw repos for trussed-main

### DIFF
--- a/.github/workflows/firmwares.yml
+++ b/.github/workflows/firmwares.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  firmwares:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: trussed
+
+      - name: Checkout solokeys/solo2
+        run: git clone https://github.com/solokeys/solo2 solo2
+      
+      - name: Checkout Nitrokey/nitrokey-3-firmware
+        run: git clone https://github.com/Nitrokey/nitrokey-3-firmware nk3
+
+      - name: Install littlefs2-sys/micro-ecc-sys build dependencies
+        shell: bash
+        run: |
+          apt-get update && apt-get install sudo
+          env && pwd && sudo apt-get update -y -qq && sudo apt-get install -y -qq llvm libc6-dev-i386 libclang-dev clang git
+
+      - uses: fiam/arm-none-eabi-gcc@v1
+        with:
+          release: "10-2020-q4"
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: thumbv8m.main-none-eabi
+          override: true
+          components: llvm-tools-preview
+
+
+      - name: cargo install cargo-binutils
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-binutils
+          version: latest
+          use-tool-cache: true
+
+      - name: cargo install flip-link
+        uses: actions-rs/install@v0.1
+        with:
+          crate: flip-link
+          version: latest
+          use-tool-cache: true      
+
+      - name: Patch solo2 trussed-dependency
+        run: | 
+          echo "[patch.crates-io]" >> solo2/runners/lpc55/Cargo.toml
+          echo "trussed = { path = '../../../trussed' }" >> solo2/runners/lpc55/Cargo.toml 
+
+      # - name: Patch Nk3 trussed-dependency -> currently not, as we already patch trussed 
+      #  run: | 
+      #    echo "[patch.crates-io]" >> nk3/runners/lpc55/Cargo.toml
+      #    echo "trussed = { git = 'https://github.com/trussed-dev/trussed' }" >> nk3/runners/lpc55/Cargo.toml 
+
+      - name: Build Solo2 Firmware
+        run: make build-release -C solo2/runners/lpc55
+      
+      - name: Build Nitrokey-3 Firmware
+        run: make -C nk3/runners/lpc55


### PR DESCRIPTION
* patch `solo2` using `patch.crate-io` after checkout
* don't patch `nitrokey-3-firmware` for now, as its current upstream uses Nitrokey's trussed git already, change back later
* checking out multiple repos failed with `actions/checkout@v2` might be an issue with `act`, no problem or issue would keep it that way so it's locally testable 
