### PR TITLE
Add low-level store activate; correctly set MAX_SERVICE_CLIENTS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ entropy = "0.4.0"
 # rand_core = { version = "0.5", features = ["getrandom"] }
 
 [features]
-default = ["default-mechanisms", "clients-1"]
+default = ["default-mechanisms", "clients-5"]
 verbose-tests = ["littlefs2/ll-assertions"]
 verbose-lfs = ["littlefs2/ll-assertions", "littlefs2/ll-trace"]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,33 @@ pub type MAX_PATH_LENGTH = consts::U256;
 pub const MAX_KEY_MATERIAL_LENGTH: usize = 128;
 // must be above + 4
 pub const MAX_SERIALIZED_KEY_LENGTH: usize = 132;
-pub type MAX_SERVICE_CLIENTS = consts::U5;
+cfg_if::cfg_if! {
+	if #[cfg(feature = "clients-12")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U12;
+	} else if #[cfg(feature = "clients-11")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U11;
+	} else if #[cfg(feature = "clients-10")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U10;
+	} else if #[cfg(feature = "clients-9")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U9;
+	} else if #[cfg(feature = "clients-8")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U8;
+	} else if #[cfg(feature = "clients-7")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U7;
+	} else if #[cfg(feature = "clients-6")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U6;
+	} else if #[cfg(feature = "clients-5")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U5;
+	} else if #[cfg(feature = "clients-4")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U4;
+	} else if #[cfg(feature = "clients-3")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U3;
+	} else if #[cfg(feature = "clients-2")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U2;
+	} else if #[cfg(feature = "clients-1")] {
+		pub type MAX_SERVICE_CLIENTS = consts::U1;
+	}
+}
 pub const MAX_SHORT_DATA_LENGTH: usize = 128;
 pub const MAX_SIGNATURE_LENGTH: usize = 72;
 pub const MAX_USER_ATTRIBUTE_LENGTH: usize = 256;

--- a/src/store.rs
+++ b/src/store.rs
@@ -235,6 +235,24 @@ macro_rules! store { (
         }
 
         #[allow(dead_code)]
+        pub fn init_raw(ifs: &'static littlefs2::fs::Filesystem<$Ifs>,
+                        efs: &'static littlefs2::fs::Filesystem<$Efs>,
+                        vfs: &'static littlefs2::fs::Filesystem<$Vfs>
+        )
+            -> Self
+        {
+            let store_ifs = $crate::store::Fs::new(ifs);
+            let store_efs = $crate::store::Fs::new(efs);
+            let store_vfs = $crate::store::Fs::new(vfs);
+            unsafe {
+                Self::ifs_ptr().write(store_ifs);
+                Self::efs_ptr().write(store_efs);
+                Self::vfs_ptr().write(store_vfs);
+            }
+            Self::claim().unwrap()
+        }
+
+        #[allow(dead_code)]
         pub fn attach(internal_fs: $Ifs, external_fs: $Efs, volatile_fs: $Vfs) -> Self {
             Self::init(internal_fs, external_fs, volatile_fs, false)
         }


### PR DESCRIPTION
* `MAX_SERVICE_CLIENTS` was always set to 5, now correctly set it according to the feature provided
* add `store::activate` to allow offloading filesystem/storage initialization into the runner