### PR TITLE
Add metadata method to the FilesystemClient and Filestore traits

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -419,7 +419,7 @@ pub mod reply {
           - data: Message
 
         Metadata:
-          - metadata: crate::types::Metadata
+          - metadata: Option<crate::types::Metadata>
 
         RemoveDir:
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -44,6 +44,7 @@ generate_enums! {
     ReadDirFilesFirst: 13
     ReadDirFilesNext: 14
     ReadFile: 15
+    Metadata: 26 
     // ReadCounter: 7
     RandomBytes: 16
     SerializeKey: 17
@@ -232,6 +233,10 @@ pub mod request {
           - location: Location
           - path: PathBuf
 
+        Metadata:
+          - location: Location
+          - path: PathBuf
+
         RemoveFile:
           - location: Location
           - path: PathBuf
@@ -412,6 +417,9 @@ pub mod reply {
 
         ReadFile:
           - data: Message
+
+        Metadata:
+          - metadata: crate::types::Metadata
 
         RemoveDir:
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -408,6 +408,12 @@ impl<P: Platform> ServiceResources<P> {
                 }))
             }
 
+            Request::Metadata(request) => {
+                Ok(Reply::Metadata(reply::Metadata{
+                    metadata: filestore.metadata(&request.path, request.location)?
+                }))
+            }
+
             Request::RandomBytes(request) => {
                 if request.count < 1024 {
                     let mut bytes = Message::new();

--- a/src/store.rs
+++ b/src/store.rs
@@ -524,6 +524,16 @@ pub fn exists(store: impl Store, location: Location, path: &Path) -> bool {
 }
 
 #[inline(never)]
+pub fn metadata(store: impl Store, location: Location, path: &Path) -> Result<Metadata, Error> {
+    debug_now!("checking existence of {}", &path);
+    match location {
+        Location::Internal => store.ifs().metadata(path),
+        Location::External => store.efs().metadata(path),
+        Location::Volatile => store.vfs().metadata(path),
+    }.map_err(|_| Error::FilesystemReadFailure)
+}
+
+#[inline(never)]
 pub fn remove_dir(store: impl Store, location: Location, path: &Path) -> bool {
     debug_now!("remove_dir'ing {}", &path);
     let outcome = match location {

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -20,7 +20,7 @@ pub struct ReadDirFilesState {
     user_attribute: Option<UserAttribute>,
 }
 
-use littlefs2::{fs::DirEntry, path::{Path, PathBuf}};
+use littlefs2::{fs::{DirEntry, Metadata}, path::{Path, PathBuf}};
 pub type ClientId = PathBuf;
 
 pub struct ClientFilestore<S>
@@ -65,6 +65,7 @@ pub trait Filestore {
     fn read<const N: usize>(&mut self, path: &PathBuf, location: Location) -> Result<Bytes<N>>;
     fn write(&mut self, path: &PathBuf, location: Location, data: &[u8]) -> Result<()>;
     fn exists(&mut self, path: &PathBuf, location: Location) -> bool;
+    fn metadata(&mut self, path: &PathBuf, location: Location) -> Result<Metadata>;
     fn remove_file(&mut self, path: &PathBuf, location: Location) -> Result<()>;
     fn remove_dir(&mut self, path: &PathBuf, location: Location) -> Result<()>;
     fn remove_dir_all(&mut self, path: &PathBuf, location: Location) -> Result<usize>;
@@ -119,6 +120,10 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     fn exists(&mut self, path: &PathBuf, location: Location) -> bool {
         let path = self.actual_path(path);
         store::exists(self.store, location, &path)
+    }
+    fn metadata(&mut self, path: &PathBuf, location: Location) -> Result<Metadata> {
+        let path = self.actual_path(path);
+        store::metadata(self.store, location, &path)
     }
 
     fn remove_file(&mut self, path: &PathBuf, location: Location) -> Result<()> {

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -65,7 +65,7 @@ pub trait Filestore {
     fn read<const N: usize>(&mut self, path: &PathBuf, location: Location) -> Result<Bytes<N>>;
     fn write(&mut self, path: &PathBuf, location: Location, data: &[u8]) -> Result<()>;
     fn exists(&mut self, path: &PathBuf, location: Location) -> bool;
-    fn metadata(&mut self, path: &PathBuf, location: Location) -> Result<Metadata>;
+    fn metadata(&mut self, path: &PathBuf, location: Location) -> Result<Option<Metadata>>;
     fn remove_file(&mut self, path: &PathBuf, location: Location) -> Result<()>;
     fn remove_dir(&mut self, path: &PathBuf, location: Location) -> Result<()>;
     fn remove_dir_all(&mut self, path: &PathBuf, location: Location) -> Result<usize>;
@@ -121,7 +121,7 @@ impl<S: Store> Filestore for ClientFilestore<S> {
         let path = self.actual_path(path);
         store::exists(self.store, location, &path)
     }
-    fn metadata(&mut self, path: &PathBuf, location: Location) -> Result<Metadata> {
+    fn metadata(&mut self, path: &PathBuf, location: Location) -> Result<Option<Metadata>> {
         let path = self.actual_path(path);
         store::metadata(self.store, location, &path)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ pub use heapless::{
 pub use crate::Bytes;
 
 pub use littlefs2::{
-    fs::{DirEntry, Filesystem},
+    fs::{DirEntry, Metadata, Filesystem},
     driver::Storage as LfsStorage,
     io::Result as LfsResult,
     path::PathBuf,


### PR DESCRIPTION
This method allows efficient probing of files and directories, and is especially useful to know if they exist or not.