### PR TITLE
Fix needless_borrow clippy warnings

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -464,8 +464,8 @@ pub trait CryptoClient: PollClient {
         let r = self.request(request::Verify {
             mechanism,
             key,
-            message: Message::from_slice(&message).expect("all good"),
-            signature: Signature::from_slice(&signature).expect("all good"),
+            message: Message::from_slice(message).expect("all good"),
+            signature: Signature::from_slice(signature).expect("all good"),
             format,
         })?;
         r.client.syscall();

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -287,7 +287,7 @@ pub trait Totp: CryptoClient {
         -> ClientResult<'_, reply::Sign, Self>
     {
         self.sign(Mechanism::Totp, key,
-            &timestamp.to_le_bytes().as_ref(),
+            timestamp.to_le_bytes().as_ref(),
             SignatureSerialization::Raw,
         )
     }

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -46,7 +46,7 @@ impl Encrypt for super::Aes256Cbc
         // The padding space should be big enough for padding, otherwise method will return Err(BlockModeError).
 		let ciphertext = cipher.encrypt(&mut buffer, l).unwrap();
 
-        let ciphertext = Message::from_slice(&ciphertext).unwrap();
+        let ciphertext = Message::from_slice(ciphertext).unwrap();
         Ok(reply::Encrypt { ciphertext, nonce: ShortData::new(), tag: ShortData::new()  })
     }
 }
@@ -120,7 +120,7 @@ impl Decrypt for super::Aes256Cbc
         // hprintln!("symmetric key: {:?}", &symmetric_key).ok();
 		let plaintext = cipher.decrypt(&mut buffer).unwrap();
         // hprintln!("decrypted: {:?}", &plaintext).ok();
-        let plaintext = Message::from_slice(&plaintext).unwrap();
+        let plaintext = Message::from_slice(plaintext).unwrap();
 
         Ok(reply::Decrypt { plaintext: Some(plaintext) })
     }

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -74,14 +74,14 @@ impl Decrypt for super::Chacha8Poly1305
 
         let symmetric_key = &serialized[..32];
 
-        let aead = ChaCha8Poly1305::new(&GenericArray::clone_from_slice(&symmetric_key));
+        let aead = ChaCha8Poly1305::new(&GenericArray::clone_from_slice(symmetric_key));
 
         let mut plaintext = request.message.clone();
         let nonce = GenericArray::from_slice(&request.nonce);
         let tag = GenericArray::from_slice(&request.tag);
 
         let outcome = aead.decrypt_in_place_detached(
-            &nonce, &request.associated_data, &mut plaintext, &tag);
+            nonce, &request.associated_data, &mut plaintext, tag);
 
         // outcome.map_err(|_| Error::AeadError)?;
 
@@ -132,7 +132,7 @@ impl Encrypt for super::Chacha8Poly1305
         }
         // increment_nonce(&mut serialized[32..])?;
 
-        keystore.overwrite_key(location, secrecy, key_kind, key_id, &serialized)?;
+        keystore.overwrite_key(location, secrecy, key_kind, key_id, serialized)?;
 
         let (symmetric_key, generated_nonce) = serialized.split_at_mut(32);
 

--- a/src/mechanisms/ed255.rs
+++ b/src/mechanisms/ed255.rs
@@ -12,7 +12,7 @@ fn load_public_key(keystore: &mut impl Keystore, key_id: &KeyId)
     -> Result<salty::PublicKey, Error> {
 
     let public_bytes: [u8; 32] = keystore
-        .load_key(key::Secrecy::Public, Some(key::Kind::Ed255), &key_id)?
+        .load_key(key::Secrecy::Public, Some(key::Kind::Ed255), key_id)?
         .material.as_slice()
         .try_into()
         .map_err(|_| Error::InternalError)?;
@@ -27,7 +27,7 @@ fn load_keypair(keystore: &mut impl Keystore, key_id: &KeyId)
     -> Result<salty::Keypair, Error> {
 
     let seed: [u8; 32] = keystore
-        .load_key(key::Secrecy::Secret, Some(key::Kind::Ed255), &key_id)?
+        .load_key(key::Secrecy::Secret, Some(key::Kind::Ed255), key_id)?
         .material.as_slice()
         .try_into()
         .map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/hmacsha1.rs
+++ b/src/mechanisms/hmacsha1.rs
@@ -17,11 +17,11 @@ impl DeriveKey for super::HmacSha1
         let key_id = request.base_key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
-        let mut mac = HmacSha1::new_from_slice(&shared_secret.as_ref())
+        let mut mac = HmacSha1::new_from_slice(shared_secret.as_ref())
             .map_err(|_| Error::InternalError)?;
 
         if let Some(additional_data) = &request.additional_data {
-            mac.update(&additional_data);
+            mac.update(additional_data);
         }
         let derived_key: [u8; 20] = mac.finalize().into_bytes().try_into().map_err(|_| Error::InternalError)?;
         let key_id = keystore.store_key(
@@ -48,7 +48,7 @@ impl Sign for super::HmacSha1
         let key_id = request.key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
-        let mut mac = HmacSha1::new_from_slice(&shared_secret.as_ref())
+        let mut mac = HmacSha1::new_from_slice(shared_secret.as_ref())
             .map_err(|_| Error::InternalError)?;
 
         mac.update(&request.message);

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -17,11 +17,11 @@ impl DeriveKey for super::HmacSha256
         let key_id = request.base_key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
-        let mut mac = HmacSha256::new_from_slice(&shared_secret.as_ref())
+        let mut mac = HmacSha256::new_from_slice(shared_secret.as_ref())
             .map_err(|_| Error::InternalError)?;
 
         if let Some(additional_data) = &request.additional_data {
-            mac.update(&additional_data);
+            mac.update(additional_data);
         }
         let derived_key: [u8; 32] = mac.finalize().into_bytes().try_into().map_err(|_| Error::InternalError)?;
         let key_id = keystore.store_key(
@@ -48,7 +48,7 @@ impl Sign for super::HmacSha256
         let key_id = request.key;
         let shared_secret = keystore.load_key(key::Secrecy::Secret, None, &key_id)?.material;
 
-        let mut mac = HmacSha256::new_from_slice(&shared_secret.as_ref())
+        let mut mac = HmacSha256::new_from_slice(shared_secret.as_ref())
             .map_err(|_| Error::InternalError)?;
 
         mac.update(&request.message);

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -12,7 +12,7 @@ fn load_secret_key(keystore: &mut impl Keystore, key_id: &KeyId)
 
     // info_now!("loading keypair");
     let secret_scalar: [u8; 32] = keystore
-        .load_key(key::Secrecy::Secret, Some(key::Kind::P256), &key_id)?
+        .load_key(key::Secrecy::Secret, Some(key::Kind::P256), key_id)?
         .material.as_slice()
         .try_into()
         .map_err(|_| Error::InternalError)?;
@@ -27,7 +27,7 @@ fn load_public_key(keystore: &mut impl Keystore, key_id: &KeyId)
     -> Result<p256_cortex_m4::PublicKey, Error>
 {
     let compressed_public_key: [u8; 33] = keystore
-        .load_key(key::Secrecy::Public, Some(key::Kind::P256), &key_id)?
+        .load_key(key::Secrecy::Public, Some(key::Kind::P256), key_id)?
         .material.as_slice()
         .try_into()
         .map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -13,7 +13,7 @@ fn load_public_key(keystore: &mut impl Keystore, key_id: &KeyId)
     -> Result<agreement::PublicKey, Error> {
 
     let public_bytes: [u8; 32] = keystore
-        .load_key(key::Secrecy::Public, Some(key::Kind::X255), &key_id)?
+        .load_key(key::Secrecy::Public, Some(key::Kind::X255), key_id)?
         .material.as_slice()
         .try_into()
         .map_err(|_| Error::InternalError)?;
@@ -27,7 +27,7 @@ fn load_secret_key(keystore: &mut impl Keystore, key_id: &KeyId)
     -> Result<agreement::SecretKey, Error> {
 
     let seed: [u8; 32] = keystore
-        .load_key(key::Secrecy::Secret, Some(key::Kind::X255), &key_id)?
+        .load_key(key::Secrecy::Secret, Some(key::Kind::X255), key_id)?
         .material.as_slice()
         .try_into()
         .map_err(|_| Error::InternalError)?;

--- a/src/service/attest.rs
+++ b/src/service/attest.rs
@@ -148,7 +148,7 @@ pub fn try_attest(
             SerializedSignature::Ed255(signature.as_ref().try_into().unwrap())
         }
         SignatureAlgorithm::P256 => {
-            SerializedSignature::P256(heapless_bytes::Bytes::from_slice(&mechanisms::P256::sign(
+            SerializedSignature::P256(heapless_bytes::Bytes::from_slice(mechanisms::P256::sign(
                 attn_keystore,
                 &request::Sign {
                     mechanism: Mechanism::P256,
@@ -511,7 +511,7 @@ impl Encodable for Datetime<'_> {
         let tagged_slice = if &self.0[..4] < b"2050" {
             TaggedSlice::from(Tag::UTC_TIME, &self.0[2..])?
         } else {
-            TaggedSlice::from(Tag::GENERALIZED_TIME, &self.0)?
+            TaggedSlice::from(Tag::GENERALIZED_TIME, self.0)?
         };
         encoder.encode(&tagged_slice)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -133,7 +133,7 @@ pub struct Fs<S: 'static + LfsStorage> {
 impl<S: 'static + LfsStorage> core::ops::Deref for Fs<S> {
     type Target = Filesystem<'static, S>;
     fn deref(&self) -> &Self::Target {
-        &self.fs
+        self.fs
     }
 }
 

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -54,7 +54,7 @@ impl<S: Store> Certstore for ClientCertstore<S> {
     fn write_certificate(&mut self, location: Location, der: &Message) -> Result<CertId> {
         let id = CertId::new(&mut self.rng);
         let path = self.cert_path(id);
-        store::store(self.store, location, &path, &der.as_slice())?;
+        store::store(self.store, location, &path, der.as_slice())?;
         Ok(id)
     }
 }

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -22,7 +22,7 @@ where
     store: P::S,
 }
 
-impl<'a, P: Platform> ClientKeystore<P> {
+impl<P: Platform> ClientKeystore<P> {
     pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: P::S) -> Self {
         Self { client_id, rng, store }
     }
@@ -120,7 +120,7 @@ impl<P: Platform> Keystore for ClientKeystore<P> {
         ];
 
         secrecies.iter().any(|secrecy| {
-            let path = self.key_path(*secrecy, &id);
+            let path = self.key_path(*secrecy, id);
             locations.iter().any(|location| {
                 store::delete(self.store, *location, &path)
             })
@@ -179,15 +179,15 @@ impl<P: Platform> Keystore for ClientKeystore<P> {
     fn location(&self, secrecy: key::Secrecy, id: &KeyId) -> Option<Location> {
         let path = self.key_path(secrecy, id);
 
-        if path.exists(&self.store.vfs()) {
+        if path.exists(self.store.vfs()) {
             return Some(Location::Volatile);
         }
 
-        if path.exists(&self.store.ifs()) {
+        if path.exists(self.store.ifs()) {
             return Some(Location::Internal);
         }
 
-        if path.exists(&self.store.efs()) {
+        if path.exists(self.store.efs()) {
             return Some(Location::External);
         }
 


### PR DESCRIPTION
There were lots of easily fixable [needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow) which this PR fixes.