### PR TITLE
virt: Add StoreProvider trait

### DIFF
--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "virt")]
 
-use trussed::virt::{self, Client, RamStore};
+use trussed::virt::{self, Client, Ram};
 
-pub fn get<R, F: FnOnce(&mut Client<RamStore>) -> R>(test: F) -> R {
+pub fn get<R, F: FnOnce(&mut Client<Ram>) -> R>(test: F) -> R {
     virt::with_ram_client("test", |mut client| test(&mut client))
 }


### PR DESCRIPTION
With this patch, we separate the store management (i. e. resetting it
when a Service is constructed) from the actual Store implementation.
This allows us to have a static lifetime for our clients as we can take
ownership of all required resources.