### PR TITLE
Fix key confusion

### DIFF
--- a/src/mechanisms/hmacblake2s.rs
+++ b/src/mechanisms/hmacblake2s.rs
@@ -14,9 +14,11 @@ impl DeriveKey for super::HmacBlake2s {
         type HmacBlake2s = Hmac<blake2::Blake2s>;
 
         let key_id = request.base_key.object_id;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac = HmacBlake2s::new_from_slice(&shared_secret.as_ref())
             .map_err(|_| Error::InternalError)?;
@@ -51,9 +53,11 @@ impl Sign for super::HmacBlake2s {
         type HmacBlake2s = Hmac<Blake2s>;
 
         let key_id = request.key.object_id;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac = HmacBlake2s::new_from_slice(&shared_secret.as_ref())
             .map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/hmacsha1.rs
+++ b/src/mechanisms/hmacsha1.rs
@@ -14,9 +14,11 @@ impl DeriveKey for super::HmacSha1 {
         type HmacSha1 = Hmac<sha1::Sha1>;
 
         let key_id = request.base_key;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac =
             HmacSha1::new_from_slice(shared_secret.as_ref()).map_err(|_| Error::InternalError)?;
@@ -49,9 +51,11 @@ impl Sign for super::HmacSha1 {
         type HmacSha1 = Hmac<Sha1>;
 
         let key_id = request.key;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac =
             HmacSha1::new_from_slice(shared_secret.as_ref()).map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -14,9 +14,11 @@ impl DeriveKey for super::HmacSha256 {
         type HmacSha256 = Hmac<sha2::Sha256>;
 
         let key_id = request.base_key;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac =
             HmacSha256::new_from_slice(shared_secret.as_ref()).map_err(|_| Error::InternalError)?;
@@ -49,9 +51,11 @@ impl Sign for super::HmacSha256 {
         type HmacSha256 = Hmac<Sha256>;
 
         let key_id = request.key;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac =
             HmacSha256::new_from_slice(shared_secret.as_ref()).map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/hmacsha512.rs
+++ b/src/mechanisms/hmacsha512.rs
@@ -14,9 +14,11 @@ impl DeriveKey for super::HmacSha512 {
         type HmacSha512 = Hmac<sha2::Sha512>;
 
         let key_id = request.base_key.object_id;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac =
             HmacSha512::new_varkey(&shared_secret.as_ref()).map_err(|_| Error::InternalError)?;
@@ -48,9 +50,11 @@ impl Sign for super::HmacSha512 {
         type HmacSha512 = Hmac<Sha512>;
 
         let key_id = request.key.object_id;
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, &key_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::WrongKeyKind);
+        }
+        let shared_secret = key.material;
 
         let mut mac =
             HmacSha512::new_varkey(&shared_secret.as_ref()).map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/sha256.rs
+++ b/src/mechanisms/sha256.rs
@@ -12,9 +12,11 @@ impl DeriveKey for super::Sha256 {
     ) -> Result<reply::DeriveKey, Error> {
         let base_id = &request.base_key;
 
-        let shared_secret = keystore
-            .load_key(key::Secrecy::Secret, None, base_id)?
-            .material;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &base_id)?;
+        if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
+            return Err(Error::NoSuchKey);
+        }
+        let shared_secret = key.material;
 
         // hash it
         use sha2::digest::Digest;

--- a/tests/aes256cbc.rs
+++ b/tests/aes256cbc.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "virt")]
+
+use trussed::client::CryptoClient;
+use trussed::syscall;
+
+mod client;
+
+use trussed::types::Location::*;
+use trussed::types::{Mechanism, StorageAttributes};
+
+use aes::Aes256;
+use block_modes::block_padding::ZeroPadding;
+use block_modes::{BlockMode, Cbc};
+use sha2::digest::Digest;
+
+#[test]
+fn aes256cbc() {
+    client::get(|client| {
+        let secret = syscall!(client.unsafe_inject_shared_key(&[], Volatile)).key;
+        let key =
+            syscall!(client.derive_key(Mechanism::Sha256, secret, None, StorageAttributes::new()))
+                .key;
+        let ciphertext =
+            syscall!(client.encrypt(Mechanism::Aes256Cbc, key, &[48; 64], &[], None)).ciphertext;
+
+        let hash = sha2::Sha256::new();
+        let key_ref = hash.finalize();
+        let cipher = Cbc::<Aes256, ZeroPadding>::new_from_slices(&key_ref, &[0; 16]).unwrap();
+        let mut buffer = [48; 64];
+        cipher.encrypt(&mut buffer, 64).unwrap();
+        assert_ne!(buffer, [48; 64]);
+        assert_eq!(buffer.as_slice(), *ciphertext);
+
+        let plaintext =
+            syscall!(client.decrypt(Mechanism::Aes256Cbc, key, &ciphertext, &[], &[], &[]))
+                .plaintext
+                .unwrap();
+        assert_eq!(plaintext, &[48; 64]);
+    })
+}

--- a/tests/key_confusion.rs
+++ b/tests/key_confusion.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "virt")]
+
+use serial_test::serial;
+use trussed::client::mechanisms::{P256, X255};
+use trussed::client::CryptoClient;
+use trussed::error::Error;
+use trussed::types::{KeyId, Mechanism, SignatureSerialization};
+use trussed::{syscall, try_syscall};
+
+mod client;
+
+use trussed::types::Location::*;
+
+fn assert_sign_mechanims_reject(key: KeyId, client: &mut impl CryptoClient) {
+    for m in [
+        Mechanism::Ed255,
+        Mechanism::HmacBlake2s,
+        Mechanism::HmacSha1,
+        Mechanism::HmacSha256,
+        Mechanism::HmacSha512,
+    ] {
+        let res = try_syscall!(client.sign(m, key, &[48; 32], SignatureSerialization::Raw));
+        assert!(
+            res == Err(Error::WrongKeyKind)
+                || res == Err(Error::MechanismNotAvailable)
+                || res == Err(Error::NoSuchKey),
+            "Got result: {res:?}"
+        );
+    }
+}
+
+fn assert_encrypt_mechanims_reject(key: KeyId, client: &mut impl CryptoClient) {
+    for m in [Mechanism::Aes256Cbc, Mechanism::Chacha8Poly1305] {
+        let res_encrypt = try_syscall!(client.encrypt(m, key, b"", b"", None));
+        assert!(
+            res_encrypt == Err(Error::WrongKeyKind)
+                || res_encrypt == Err(Error::MechanismNotAvailable)
+                || res_encrypt == Err(Error::NoSuchKey),
+            "Got result: {res_encrypt:?}"
+        );
+
+        let res_decrypt = try_syscall!(client.decrypt(m, key, b"", b"", b"", b""));
+        assert!(
+            res_decrypt == Err(Error::WrongKeyKind)
+                || res_decrypt == Err(Error::MechanismNotAvailable)
+                || res_decrypt == Err(Error::NoSuchKey),
+            "Got result: {res_decrypt:?}"
+        );
+    }
+}
+
+#[test]
+#[serial]
+fn p256() {
+    client::get(|client| {
+        let sk1 = syscall!(client.generate_p256_private_key(Internal)).key;
+        let pk1 = syscall!(client.derive_p256_public_key(sk1, Volatile)).key;
+
+        assert_sign_mechanims_reject(sk1, client);
+        assert_sign_mechanims_reject(pk1, client);
+        assert_encrypt_mechanims_reject(sk1, client);
+        assert_encrypt_mechanims_reject(pk1, client);
+    })
+}
+
+#[test]
+#[serial]
+fn x255() {
+    client::get(|client| {
+        let sk1 = syscall!(client.generate_x255_secret_key(Internal)).key;
+        let pk1 = syscall!(client.derive_x255_public_key(sk1, Volatile)).key;
+        assert_sign_mechanims_reject(sk1, client);
+        assert_sign_mechanims_reject(pk1, client);
+        assert_encrypt_mechanims_reject(sk1, client);
+        assert_encrypt_mechanims_reject(pk1, client);
+    })
+}

--- a/tests/tdes.rs
+++ b/tests/tdes.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "virt")]
+
+use trussed::client::CryptoClient;
+use trussed::syscall;
+
+mod client;
+
+use trussed::types::Location::*;
+use trussed::types::Mechanism;
+
+use hex_literal::hex;
+
+#[test]
+fn tdes() {
+    client::get(|client| {
+        let key = syscall!(client.unsafe_inject_shared_key(&[48; 24], Volatile)).key;
+        let ciphertext =
+            syscall!(client.encrypt(Mechanism::Tdes, key, &[48; 8], &[], None)).ciphertext;
+
+        assert_eq!(ciphertext, hex!("f47bb46273b15eb5"),);
+
+        let plaintext = syscall!(client.decrypt(Mechanism::Tdes, key, &ciphertext, &[], &[], &[]))
+            .plaintext
+            .unwrap();
+        assert_eq!(plaintext, &[48; 8]);
+    })
+}


### PR DESCRIPTION
This PR fixes key type confusions that could happen previously. Because many symmetric operations didn't check the `Kind` of the key they used, it was possible to use an ECC key for HMAC or AES.

This PR also prevents using `Shared` as a key unless it's been through `DeriveKey`. I don't think this breaks anything deployed (I checked for `fido-authenticator`.

I also find it weird that `unsafe_inject_shared_secret` yields a key of `Kind::Shared` IMO it should be `Symmetric` so that it can be used for symmetric cryptography. I feel like right now the distinction between `Kind::Shared` and `Kind::Symmetric` doesn't bring anything.