### PR TITLE
Add support for extracting keys

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -79,6 +79,10 @@ bitflags::bitflags! {
         const LOCAL = 1 << 0;
         /// Set if the key is a secret key.
         const SENSITIVE = 1 << 1;
+        // Reserved for future use
+        // const WRAPPABLE = 1 << 3;
+        /// This flag currently only applies to `kind::Shared`
+        const SERIALIZABLE = 1 << 4;
     }
 }
 

--- a/src/mechanisms.rs
+++ b/src/mechanisms.rs
@@ -17,6 +17,9 @@ mod aes256cbc;
 pub struct Chacha8Poly1305 {}
 mod chacha8poly1305;
 
+pub struct SharedSecret {}
+mod shared_secret;
+
 pub struct Ed255 {}
 mod ed255;
 

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -54,10 +54,20 @@ impl Agree for super::P256 {
 
         let shared_secret = secret_key.agree(&public_key);
 
+        let flags = if request.attributes.serializable {
+            key::Flags::SERIALIZABLE
+        } else {
+            key::Flags::empty()
+        };
+        let info = key::Info {
+            kind: key::Kind::Shared(shared_secret.as_bytes().len()),
+            flags,
+        };
+
         let key_id = keystore.store_key(
             request.attributes.persistence,
             key::Secrecy::Secret,
-            key::Kind::Shared(32),
+            info,
             shared_secret.as_bytes(),
         )?;
 

--- a/src/mechanisms/shared_secret.rs
+++ b/src/mechanisms/shared_secret.rs
@@ -1,0 +1,30 @@
+use crate::api::*;
+use crate::error::Error;
+use crate::key;
+use crate::service::*;
+use crate::types::*;
+
+impl SerializeKey for super::SharedSecret {
+    #[inline(never)]
+    fn serialize_key(
+        keystore: &mut impl Keystore,
+        request: &request::SerializeKey,
+    ) -> Result<reply::SerializeKey, Error> {
+        if request.format != KeySerialization::Raw {
+            return Err(Error::InvalidSerializationFormat);
+        }
+
+        let key = keystore.load_key(key::Secrecy::Secret, None, &request.key)?;
+        if !matches!(key.kind, key::Kind::Shared(..)) {
+            return Err(Error::MechanismParamInvalid);
+        };
+
+        if !key.flags.contains(key::Flags::SERIALIZABLE) {
+            return Err(Error::InvalidSerializedKey);
+        };
+        let mut serialized_key = Message::new();
+        serialized_key.extend_from_slice(&key.material).unwrap();
+
+        Ok(reply::SerializeKey { serialized_key })
+    }
+}

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -54,10 +54,20 @@ impl Agree for super::X255 {
 
         let shared_secret = secret_key.agree(&public_key).to_bytes();
 
+        let flags = if request.attributes.serializable {
+            key::Flags::SERIALIZABLE
+        } else {
+            key::Flags::empty()
+        };
+        let info = key::Info {
+            kind: key::Kind::Shared(shared_secret.len()),
+            flags,
+        };
+
         let key_id = keystore.store_key(
             request.attributes.persistence,
             key::Secrecy::Secret,
-            key::Kind::Shared(32),
+            info,
             &shared_secret,
         )?;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -429,6 +429,7 @@ impl<P: Platform> ServiceResources<P> {
                     Mechanism::Ed255 => mechanisms::Ed255::serialize_key(keystore, request),
                     Mechanism::P256 => mechanisms::P256::serialize_key(keystore, request),
                     Mechanism::X255 => mechanisms::X255::serialize_key(keystore, request),
+                    Mechanism::SharedSecret => mechanisms::SharedSecret::serialize_key(keystore, request),
                     _ => Err(Error::MechanismNotAvailable),
 
                 }.map(Reply::SerializeKey)

--- a/src/service/attest.rs
+++ b/src/service/attest.rs
@@ -73,9 +73,7 @@ pub fn try_attest(
                     mechanism: Mechanism::Ed255,
                     base_key: request.private_key,
                     additional_data: None,
-                    attributes: StorageAttributes {
-                        persistence: Location::Volatile,
-                    },
+                    attributes: StorageAttributes::new().set_persistence(Location::Volatile),
                 },
             )?
             .key;
@@ -106,9 +104,7 @@ pub fn try_attest(
                     mechanism: Mechanism::P256,
                     base_key: request.private_key,
                     additional_data: None,
-                    attributes: StorageAttributes {
-                        persistence: Location::Volatile,
-                    },
+                    attributes: StorageAttributes::new().set_persistence(Location::Volatile),
                 },
             )?
             .key;

--- a/src/types.rs
+++ b/src/types.rs
@@ -509,6 +509,8 @@ pub enum Mechanism {
     Totp,
     Trng,
     X255,
+    /// Used to serialize the output of a diffie-hellman
+    SharedSecret,
 }
 
 pub type LongData = Bytes<MAX_LONG_DATA_LENGTH>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -434,6 +434,7 @@ pub enum Location {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct StorageAttributes {
     // each object must have a unique ID
     // unique_id: UniqueId,

--- a/src/types.rs
+++ b/src/types.rs
@@ -445,6 +445,10 @@ pub struct StorageAttributes {
     // // cryptoki: token (vs session) object
     // persistent: bool,
     pub persistence: Location,
+
+    /// Wether a the result of an [`agree`](crate::client::CryptoClient::agree) can be serialized
+    /// with [`serialize_key`](crate::client::CryptoClient::serialize_key)
+    pub serializable: bool,
     // cryptoki: user must be logged in
     // private: bool,
 
@@ -458,6 +462,11 @@ impl StorageAttributes {
         self.persistence = persistence;
         self
     }
+
+    pub fn set_serializable(mut self, serializable: bool) -> Self {
+        self.serializable = serializable;
+        self
+    }
 }
 
 impl StorageAttributes {
@@ -468,6 +477,7 @@ impl StorageAttributes {
             // label: String::new(),
             // persistent: false,
             persistence: Location::Volatile,
+            serializable: false,
             // modifiable: true,
             // copyable: true,
             // destroyable: true,

--- a/tests/p256.rs
+++ b/tests/p256.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "virt")]
 
 use trussed::client::mechanisms::{HmacSha256, P256};
-use trussed::syscall;
+use trussed::client::CryptoClient;
+use trussed::types::{KeySerialization, Mechanism, StorageAttributes};
+use trussed::{syscall, try_syscall};
 
 mod client;
 
@@ -16,11 +18,27 @@ fn p256_agree() {
         let pk2 = syscall!(client.derive_p256_public_key(sk2, Volatile)).key;
 
         let secret1 = syscall!(client.agree_p256(sk1, pk2, Volatile)).shared_secret;
-        let secret2 = syscall!(client.agree_p256(sk2, pk1, Volatile)).shared_secret;
+
+        let secret2 = syscall!(client.agree(
+            Mechanism::P256,
+            sk2,
+            pk1,
+            StorageAttributes::new().set_serializable(true)
+        ))
+        .shared_secret;
 
         // Trussed® won't give out secrets, but lets us use them
         let derivative1 = syscall!(client.sign_hmacsha256(secret1, &[])).signature;
         let derivative2 = syscall!(client.sign_hmacsha256(secret2, &[])).signature;
         assert_eq!(derivative1, derivative2);
+
+        assert!(try_syscall!(client.serialize_key(
+            Mechanism::SharedSecret,
+            secret1,
+            KeySerialization::Raw
+        ))
+        .is_err());
+        let _ =
+            syscall!(client.serialize_key(Mechanism::SharedSecret, secret2, KeySerialization::Raw));
     })
 }

--- a/tests/x255.rs
+++ b/tests/x255.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "virt")]
 
 use trussed::client::mechanisms::{HmacSha256, X255};
-use trussed::syscall;
+use trussed::client::CryptoClient;
+use trussed::types::{KeySerialization, Mechanism, StorageAttributes};
+use trussed::{syscall, try_syscall};
 
 mod client;
 
@@ -16,11 +18,26 @@ fn x255_agree() {
         let pk2 = syscall!(client.derive_x255_public_key(sk2, Volatile)).key;
 
         let secret1 = syscall!(client.agree_x255(sk1, pk2, Volatile)).shared_secret;
-        let secret2 = syscall!(client.agree_x255(sk2, pk1, Volatile)).shared_secret;
+        let secret2 = syscall!(client.agree(
+            Mechanism::X255,
+            sk2,
+            pk1,
+            StorageAttributes::new().set_serializable(true)
+        ))
+        .shared_secret;
 
         // Trussed® won't give out secrets, but lets us use them
         let derivative1 = syscall!(client.sign_hmacsha256(secret1, &[])).signature;
         let derivative2 = syscall!(client.sign_hmacsha256(secret2, &[])).signature;
         assert_eq!(derivative1, derivative2);
+
+        assert!(try_syscall!(client.serialize_key(
+            Mechanism::SharedSecret,
+            secret1,
+            KeySerialization::Raw
+        ))
+        .is_err());
+        let _ =
+            syscall!(client.serialize_key(Mechanism::SharedSecret, secret2, KeySerialization::Raw));
     })
 }


### PR DESCRIPTION
This PR follows what was discussed in https://github.com/trussed-dev/trussed/discussions/36.

There are two issues to solve:

- [ ] Migrations: Already created public keys will have the `EXTRACTABLE` flag off by default, when it should be set, otherwise it will not be possible to serialize them.
- [ ] What mechanism should be used to serialize a symmetric key?