### PR TITLE
Add multiple (Service) Backends abstraction

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -99,6 +99,11 @@ generate_enums! {
     ReadCertificate: 61
     WriteCertificate: 62
 
+    ///////////////////
+    // Backend Mgmt. //
+    ///////////////////
+    SetServiceBackends: 90
+
     ///////////
     // Other //
     ///////////
@@ -332,6 +337,8 @@ pub mod request {
           - location: Location
           - der: Message
 
+        SetServiceBackends:
+          - backends: Vec<ServiceBackends, 2>
     }
 }
 
@@ -482,5 +489,8 @@ pub mod reply {
 
         WriteCertificate:
           - id: CertId
+
+        SetServiceBackends:
+
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,6 +116,7 @@ pub trait PollClient {
     ) -> ClientResult<'_, T, Self>;
     fn poll(&mut self) -> core::task::Poll<core::result::Result<Reply, Error>>;
     fn syscall(&mut self);
+    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>) -> ClientResult<'_, reply::SetServiceBackends, Self>;
 }
 
 pub struct FutureResult<'c, T, C: ?Sized>
@@ -237,6 +238,15 @@ where
     fn syscall(&mut self) {
         self.syscall.syscall()
     }
+
+    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>)
+        -> ClientResult<'_, reply::SetServiceBackends, Self>
+    {
+        let r = self.request(request::SetServiceBackends { backends })?;
+        r.client.syscall();
+        Ok(r)
+    }
+
 }
 
 impl<S: Syscall> CertificateClient for ClientImplementation<S> {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,7 +116,10 @@ pub trait PollClient {
     ) -> ClientResult<'_, T, Self>;
     fn poll(&mut self) -> core::task::Poll<core::result::Result<Reply, Error>>;
     fn syscall(&mut self);
-    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>) -> ClientResult<'_, reply::SetServiceBackends, Self>;
+    fn set_service_backends(
+        &mut self,
+        backends: Vec<ServiceBackends, 2>,
+    ) -> ClientResult<'_, reply::SetServiceBackends, Self>;
 }
 
 pub struct FutureResult<'c, T, C: ?Sized>
@@ -239,14 +242,14 @@ where
         self.syscall.syscall()
     }
 
-    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>)
-        -> ClientResult<'_, reply::SetServiceBackends, Self>
-    {
+    fn set_service_backends(
+        &mut self,
+        backends: Vec<ServiceBackends, 2>,
+    ) -> ClientResult<'_, reply::SetServiceBackends, Self> {
         let r = self.request(request::SetServiceBackends { backends })?;
         r.client.syscall();
         Ok(r)
     }
-
 }
 
 impl<S: Syscall> CertificateClient for ClientImplementation<S> {}

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -3,7 +3,7 @@ use interchange::Responder;
 
 use crate::api::{Reply, Request};
 use crate::error::Error;
-use crate::types::ClientId;
+use crate::types::ClientContext;
 
 cfg_if::cfg_if! {
 
@@ -72,7 +72,7 @@ pub struct ServiceEndpoint {
     pub interchange: Responder<TrussedInterchange>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
-    pub client_id: ClientId,
+    pub client_ctx: ClientContext,
 }
 
 // pub type ClientEndpoint = Requester<TrussedInterchange>;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,9 +7,10 @@
 //! TODO: Currently, `Platform::R` lacks the `CryptoRng` bound.
 
 // pub use rand_core::{CryptoRng, RngCore};
+use crate::api::{Reply, Request};
+use crate::error::Error;
 pub use crate::store::Store;
-pub use crate::types::consent;
-pub use crate::types::{reboot, ui};
+pub use crate::types::{consent, reboot, ui, ClientContext, ServiceBackends};
 pub use rand_core::{CryptoRng, RngCore};
 
 pub trait UserInterface {
@@ -63,54 +64,66 @@ pub unsafe trait Platform {
     fn rng(&mut self) -> &mut Self::R;
     fn store(&self) -> Self::S;
     fn user_interface(&mut self) -> &mut Self::UI;
+    fn platform_reply_to(
+        &mut self,
+        backend_id: ServiceBackends,
+        client_id: &mut ClientContext,
+        request: &Request,
+    ) -> Result<Reply, Error>;
 }
 
 #[macro_export]
-macro_rules! platform {
-    (
+macro_rules! platform { (
     $PlatformName:ident,
     R: $Rng:ty,
     S: $Store:ty,
     UI: $UserInterface:ty,
+    $($BackendID:pat, $BackendName:ident, $BackendType:ty),*
 ) => {
-        /// Platform struct implemented `trussed::Platform`, generated
-        /// by a Trussed-supplied macro at call site, using the platform-specific
-        /// implementations of its components.
-        pub struct $PlatformName {
-            rng: $Rng,
-            store: $Store,
-            user_interface: $UserInterface,
+
+    /// Platform struct implemented `trussed::Platform`, generated
+    /// by a Trussed-supplied macro at call site, using the platform-specific
+    /// implementations of its components.
+    pub struct $PlatformName {
+        rng: $Rng,
+        store: $Store,
+        user_interface: $UserInterface,
+        $($BackendName: $BackendType),*
+    }
+
+    impl $PlatformName {
+        pub fn new(rng: $Rng, store: $Store, user_interface: $UserInterface, $($BackendName: $BackendType),*) -> Self {
+            Self { rng, store, user_interface, $($BackendName),* }
+        }
+    }
+
+    unsafe impl $crate::platform::Platform for $PlatformName {
+        type R = $Rng;
+        type S = $Store;
+        type UI = $UserInterface;
+
+        fn user_interface(&mut self) -> &mut Self::UI {
+            &mut self.user_interface
         }
 
-        impl $PlatformName {
-            pub fn new(rng: $Rng, store: $Store, user_interface: $UserInterface) -> Self {
-                Self {
-                    rng,
-                    store,
-                    user_interface,
-                }
-            }
+        fn rng(&mut self) -> &mut Self::R {
+            &mut self.rng
         }
 
-        unsafe impl $crate::platform::Platform for $PlatformName {
-            type R = $Rng;
-            type S = $Store;
-            type UI = $UserInterface;
-
-            fn user_interface(&mut self) -> &mut Self::UI {
-                &mut self.user_interface
-            }
-
-            fn rng(&mut self) -> &mut Self::R {
-                &mut self.rng
-            }
-
-            fn store(&self) -> Self::S {
-                self.store
-            }
+        fn store(&self) -> Self::S {
+            self.store
         }
-    };
-}
+
+        #[allow(unused)]
+        fn platform_reply_to(&mut self, backend_id: $crate::types::ServiceBackends, client_id: &mut $crate::types::ClientContext, request: &$crate::api::Request) -> Result<$crate::api::Reply, $crate::error::Error> {
+            $(if let $BackendID = backend_id {
+                let b: &mut dyn $crate::types::ServiceBackend = &mut self.$BackendName;
+                return b.reply_to(client_id, request);
+            } );*
+            return Err($crate::error::Error::RequestNotAvailable);
+        }
+    }
+}}
 
 /// Trussed client will call this method when making a Trussed request.
 /// This is intended to trigger a secure context on the platform.

--- a/src/service.rs
+++ b/src/service.rs
@@ -572,8 +572,14 @@ impl<P: Platform> ServiceResources<P> {
             }
 
             Request::SetServiceBackends(request) => {
+                /* as long as we don't do backend selection per syscall,
+                   reject clients that want to drop the software backend;
+		   otherwise they will never be able to switch again! */
+                if !request.backends.contains(&ServiceBackends::Software) {
+                    return Err(Error::InternalError);
+                }
                 client_ctx.backends.clear();
-                client_ctx.backends.extend_from_slice(&request.backends);
+                client_ctx.backends.extend_from_slice(&request.backends).unwrap();
                 Ok(Reply::SetServiceBackends(reply::SetServiceBackends {}))
             }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -58,7 +58,7 @@ where
 {
     pub(crate) platform: P,
     // // Option?
-    // currently_serving: ClientId,
+    // currently_serving: ClientContext,
     // TODO: how/when to clear
     read_dir_files_state: Option<ReadDirFilesState>,
     read_dir_state: Option<ReadDirState>,
@@ -90,7 +90,11 @@ unsafe impl<P: Platform> Send for Service<P> {}
 
 impl<P: Platform> ServiceResources<P> {
     #[inline(never)]
-    pub fn reply_to(&mut self, client_id: PathBuf, request: &Request) -> Result<Reply, Error> {
+    pub fn reply_to(
+        &mut self,
+        client_id: &mut ClientContext,
+        request: &Request,
+    ) -> Result<Reply, Error> {
         // TODO: what we want to do here is map an enum to a generic type
         // Is there a nicer way to do this?
 
@@ -98,7 +102,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare keystore, bound to client_id, for cryptographic calls
         let mut keystore: ClientKeystore<P::S> = ClientKeystore::new(
-            client_id.clone(),
+            client_id.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -106,7 +110,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare certstore, bound to client_id, for cert calls
         let mut certstore: ClientCertstore<P::S> = ClientCertstore::new(
-            client_id.clone(),
+            client_id.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -114,14 +118,15 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare counterstore, bound to client_id, for counter calls
         let mut counterstore: ClientCounterstore<P::S> = ClientCounterstore::new(
-            client_id.clone(),
+            client_id.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
         let counterstore = &mut counterstore;
 
         // prepare filestore, bound to client_id, for storage calls
-        let mut filestore: ClientFilestore<P::S> = ClientFilestore::new(client_id, full_store);
+        let mut filestore: ClientFilestore<P::S> =
+            ClientFilestore::new(client_id.path.clone(), full_store);
         let filestore = &mut filestore;
 
         debug_now!("TRUSSED {:?}", request);
@@ -679,8 +684,8 @@ impl<P: Platform> Service<P> {
     ) -> Result<crate::client::ClientImplementation<S>, ()> {
         use interchange::Interchange;
         let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_id = ClientId::from(client_id.as_bytes());
-        self.add_endpoint(responder, client_id)
+        let client_ctx = ClientContext::from(client_id);
+        self.add_endpoint(responder, client_ctx)
             .map_err(|_service_endpoint| ())?;
 
         Ok(crate::client::ClientImplementation::new(requester, syscall))
@@ -696,8 +701,8 @@ impl<P: Platform> Service<P> {
     ) -> Result<crate::client::ClientImplementation<&mut Service<P>>, ()> {
         use interchange::Interchange;
         let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_id = ClientId::from(client_id.as_bytes());
-        self.add_endpoint(responder, client_id)
+        let client_ctx = ClientContext::from(client_id);
+        self.add_endpoint(responder, client_ctx)
             .map_err(|_service_endpoint| ())?;
 
         Ok(crate::client::ClientImplementation::new(requester, self))
@@ -712,8 +717,8 @@ impl<P: Platform> Service<P> {
     ) -> Result<crate::client::ClientImplementation<Service<P>>, ()> {
         use interchange::Interchange;
         let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_id = ClientId::from(client_id.as_bytes());
-        self.add_endpoint(responder, client_id)
+        let client_ctx = ClientContext::from(client_id);
+        self.add_endpoint(responder, client_ctx)
             .map_err(|_service_endpoint| ())?;
 
         Ok(crate::client::ClientImplementation::new(requester, self))
@@ -722,14 +727,14 @@ impl<P: Platform> Service<P> {
     pub fn add_endpoint(
         &mut self,
         interchange: Responder<TrussedInterchange>,
-        client_id: ClientId,
+        client_ctx: ClientContext,
     ) -> Result<(), ServiceEndpoint> {
-        if client_id == PathBuf::from("trussed") {
+        if client_ctx.path == PathBuf::from("trussed") {
             panic!("trussed is a reserved client ID");
         }
         self.eps.push(ServiceEndpoint {
             interchange,
-            client_id,
+            client_ctx,
         })
     }
 
@@ -772,7 +777,7 @@ impl<P: Platform> Service<P> {
                 // #[cfg(test)] println!("service got request: {:?}", &request);
 
                 // resources.currently_serving = ep.client_id.clone();
-                let reply_result = resources.reply_to(ep.client_id.clone(), &request);
+                let reply_result = resources.reply_to(&mut ep.client_ctx, &request);
 
                 resources
                     .platform

--- a/src/service.rs
+++ b/src/service.rs
@@ -777,7 +777,18 @@ impl<P: Platform> Service<P> {
                 // #[cfg(test)] println!("service got request: {:?}", &request);
 
                 // resources.currently_serving = ep.client_id.clone();
-                let reply_result = resources.reply_to(&mut ep.client_ctx, &request);
+
+                let mut reply_result = Err(Error::RequestNotAvailable);
+                for backend in ep.client_ctx.backends.clone() {
+                    reply_result = match backend {
+                        ServiceBackends::Software => {
+                            resources.reply_to(&mut ep.client_ctx, &request)
+                        }
+                    };
+                    if reply_result != Err(Error::RequestNotAvailable) {
+                        break;
+                    }
+                }
 
                 resources
                     .platform

--- a/src/service.rs
+++ b/src/service.rs
@@ -57,11 +57,6 @@ where
     P: Platform,
 {
     pub(crate) platform: P,
-    // // Option?
-    // currently_serving: ClientContext,
-    // TODO: how/when to clear
-    read_dir_files_state: Option<ReadDirFilesState>,
-    read_dir_state: Option<ReadDirState>,
     rng_state: Option<ChaCha8Rng>,
 }
 
@@ -69,9 +64,6 @@ impl<P: Platform> ServiceResources<P> {
     pub fn new(platform: P) -> Self {
         Self {
             platform,
-            // currently_serving: PathBuf::new(),
-            read_dir_files_state: None,
-            read_dir_state: None,
             rng_state: None,
         }
     }
@@ -763,6 +755,7 @@ impl<P: Platform> Service<P> {
     }
 
     // process one request per client which has any
+    #[allow(unreachable_patterns)]
     pub fn process(&mut self) {
         // split self since we iter-mut over eps and need &mut of the other resources
         let eps = &mut self.eps;
@@ -783,6 +776,11 @@ impl<P: Platform> Service<P> {
                     reply_result = match backend {
                         ServiceBackends::Software => {
                             resources.reply_to(&mut ep.client_ctx, &request)
+                        }
+                        sb => {
+                            resources
+                                .platform
+                                .platform_reply_to(sb, &mut ep.client_ctx, &request)
                         }
                     };
                     if reply_result != Err(Error::RequestNotAvailable) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -571,6 +571,12 @@ impl<P: Platform> ServiceResources<P> {
                     .map(|id| Reply::WriteCertificate(reply::WriteCertificate { id } ))
             }
 
+            Request::SetServiceBackends(request) => {
+                client_ctx.backends.clear();
+                client_ctx.backends.extend_from_slice(&request.backends);
+                Ok(Reply::SetServiceBackends(reply::SetServiceBackends {}))
+            }
+
             // _ => {
             //     // #[cfg(test)]
             //     // println!("todo: {:?} request!", &request);

--- a/src/service.rs
+++ b/src/service.rs
@@ -327,11 +327,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::ReadDirFirst(request) => {
                 let maybe_entry = match filestore.read_dir_first(&request.dir, request.location, request.not_before_filename.as_ref())? {
                     Some((entry, read_dir_state)) => {
-                        self.read_dir_state = Some(read_dir_state);
+                        client_id.read_dir_state = Some(read_dir_state);
                         Some(entry)
                     }
                     None => {
-                        self.read_dir_state = None;
+                        client_id.read_dir_state = None;
                         None
 
                     }
@@ -341,18 +341,18 @@ impl<P: Platform> ServiceResources<P> {
 
             Request::ReadDirNext(_request) => {
                 // ensure next call has nothing to work with, unless we store state again
-                let read_dir_state = self.read_dir_state.take();
+                let read_dir_state = client_id.read_dir_state.take();
 
                 let maybe_entry = match read_dir_state {
                     None => None,
                     Some(state) => {
                         match filestore.read_dir_next(state)? {
                             Some((entry, read_dir_state)) => {
-                                self.read_dir_state = Some(read_dir_state);
+                                client_id.read_dir_state = Some(read_dir_state);
                                 Some(entry)
                             }
                             None => {
-                                self.read_dir_state = None;
+                                client_id.read_dir_state = None;
                                 None
                             }
                         }
@@ -365,11 +365,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::ReadDirFilesFirst(request) => {
                 let maybe_data = match filestore.read_dir_files_first(&request.dir, request.location, request.user_attribute.clone())? {
                     Some((data, state)) => {
-                        self.read_dir_files_state = Some(state);
+                        client_id.read_dir_files_state = Some(state);
                         data
                     }
                     None => {
-                        self.read_dir_files_state = None;
+                        client_id.read_dir_files_state = None;
                         None
                     }
                 };
@@ -377,18 +377,18 @@ impl<P: Platform> ServiceResources<P> {
             }
 
             Request::ReadDirFilesNext(_request) => {
-                let read_dir_files_state = self.read_dir_files_state.take();
+                let read_dir_files_state = client_id.read_dir_files_state.take();
 
                 let maybe_data = match read_dir_files_state {
                     None => None,
                     Some(state) => {
                         match filestore.read_dir_files_next(state)? {
                             Some((data, state)) => {
-                                self.read_dir_files_state = Some(state);
+                                client_id.read_dir_files_state = Some(state);
                                 data
                             }
                             None => {
-                                self.read_dir_files_state = None;
+                                client_id.read_dir_files_state = None;
                                 None
                             }
                         }

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -4,14 +4,14 @@ use littlefs2::path::PathBuf;
 use crate::{
     error::{Error, Result},
     store::{self, Store},
-    types::{CertId, ClientId, Location, Message},
+    types::{CertId, Location, Message},
 };
 
 pub struct ClientCertstore<S>
 where
     S: Store,
 {
-    client_id: ClientId,
+    client_id: PathBuf,
     rng: ChaCha8Rng,
     store: S,
 }
@@ -54,7 +54,7 @@ impl<S: Store> Certstore for ClientCertstore<S> {
 }
 
 impl<S: Store> ClientCertstore<S> {
-    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: S) -> Self {
+    pub fn new(client_id: PathBuf, rng: ChaCha8Rng, store: S) -> Self {
         Self {
             client_id,
             rng,

--- a/src/store/counterstore.rs
+++ b/src/store/counterstore.rs
@@ -4,14 +4,14 @@ use littlefs2::path::PathBuf;
 use crate::{
     error::{Error, Result},
     store::{self, Store},
-    types::{ClientId, CounterId, Location},
+    types::{CounterId, Location},
 };
 
 pub struct ClientCounterstore<S>
 where
     S: Store,
 {
-    client_id: ClientId,
+    client_id: PathBuf,
     rng: ChaCha8Rng,
     store: S,
 }
@@ -19,7 +19,7 @@ where
 pub type Counter = u128;
 
 impl<S: Store> ClientCounterstore<S> {
-    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: S) -> Self {
+    pub fn new(client_id: PathBuf, rng: ChaCha8Rng, store: S) -> Self {
         Self {
             client_id,
             rng,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,8 +5,8 @@ use crate::types::*;
 use crate::*;
 use entropy::shannon_entropy;
 use interchange::Interchange;
-use littlefs2::const_ram_storage;
 use littlefs2::fs::{Allocation, Filesystem};
+use littlefs2::{const_ram_storage, consts};
 
 use crate::client::{CryptoClient as _, FilesystemClient as _};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,8 +5,8 @@ use crate::types::*;
 use crate::*;
 use entropy::shannon_entropy;
 use interchange::Interchange;
+use littlefs2::const_ram_storage;
 use littlefs2::fs::{Allocation, Filesystem};
-use littlefs2::{const_ram_storage, consts};
 
 use crate::client::{CryptoClient as _, FilesystemClient as _};
 
@@ -183,7 +183,7 @@ macro_rules! setup {
         let (test_trussed_requester, test_trussed_responder) =
             crate::pipe::TrussedInterchange::claim()
                 .expect("could not setup TEST TrussedInterchange");
-        let test_client_id = "TEST".into();
+        let test_client_id = "TEST";
 
         assert!(trussed
             .add_endpoint(test_trussed_responder, test_client_id)

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::*;
 use crate::key::Secrecy;
+use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 
 pub use crate::client::FutureResult;
 pub use crate::platform::Platform;
@@ -235,10 +236,13 @@ pub mod consent {
 /**
 The "ClientId" struct is the closest equivalent to a PCB that Trussed
 currently has. Trussed currently uses it to choose the client-specific
-subtree in the filesystem (see docs in src/store.rs).
+subtree in the filesystem (see docs in src/store.rs) and to maintain
+the walker state of the directory traversal syscalls.
 */
 pub struct ClientContext {
     pub path: PathBuf,
+    pub(crate) read_dir_state: Option<ReadDirState>,
+    pub(crate) read_dir_files_state: Option<ReadDirFilesState>,
 }
 
 impl core::convert::From<PathBuf> for ClientContext {
@@ -255,7 +259,11 @@ impl core::convert::From<&str> for ClientContext {
 
 impl ClientContext {
     pub fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self {
+            path,
+            read_dir_state: None,
+            read_dir_files_state: None,
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,9 @@ pub use littlefs2::{
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
+use crate::api::{Reply, Request};
 use crate::config::*;
+use crate::error::Error;
 use crate::key::Secrecy;
 use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 
@@ -288,10 +290,21 @@ added as payload for that enum variant.
 Backends are called from Service::process() under consideration of the
 selection and ordering the calling client has specified in its ClientId.
 */
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone)]
 pub enum ServiceBackends {
     Software,
     // SE050(Se050Parameters),
+}
+
+/**
+Each service backend implements a subset of API calls through this trait.
+*/
+pub trait ServiceBackend {
+    fn reply_to(
+        &mut self,
+        client_id: &mut ClientContext,
+        request: &Request,
+    ) -> Result<Reply, Error>;
 }
 
 // Object Hierarchy according to Cryptoki

--- a/src/types.rs
+++ b/src/types.rs
@@ -273,6 +273,33 @@ impl ClientContext {
             read_dir_files_state: None,
         }
     }
+
+    pub fn builder(path: PathBuf) -> ClientContextBuilder {
+        ClientContextBuilder::new(path)
+    }
+}
+
+pub struct ClientContextBuilder {
+    pub path: PathBuf,
+    pub backends: Vec<ServiceBackends, 2>,
+}
+
+impl ClientContextBuilder {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            backends: Vec::from_slice(&[ServiceBackends::Software]).unwrap(),
+        }
+    }
+
+    pub fn add_backend(&mut self, backend: ServiceBackends) -> &ClientContextBuilder {
+        self.backends.insert(0, backend).unwrap();
+        self
+    }
+
+    pub fn build(&self) -> ClientContext {
+        ClientContext::new(self.path.clone(), self.backends.clone())
+    }
 }
 
 /**
@@ -290,9 +317,10 @@ added as payload for that enum variant.
 Backends are called from Service::process() under consideration of the
 selection and ordering the calling client has specified in its ClientId.
 */
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum ServiceBackends {
     Software,
+    SoftwareAuth,
     // SE050(Se050Parameters),
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -232,8 +232,32 @@ pub mod consent {
 // pub type AeadNonce = [u8; 12];
 // pub type AeadTag = [u8; 16];
 
-// pub type ClientId = heapless::Vec<u8, heapless::consts::U32>;
-pub type ClientId = PathBuf;
+/**
+The "ClientId" struct is the closest equivalent to a PCB that Trussed
+currently has. Trussed currently uses it to choose the client-specific
+subtree in the filesystem (see docs in src/store.rs).
+*/
+pub struct ClientContext {
+    pub path: PathBuf,
+}
+
+impl core::convert::From<PathBuf> for ClientContext {
+    fn from(path: PathBuf) -> Self {
+        Self::new(path)
+    }
+}
+
+impl core::convert::From<&str> for ClientContext {
+    fn from(path_str: &str) -> Self {
+        Self::new(PathBuf::from(path_str))
+    }
+}
+
+impl ClientContext {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
 
 // Object Hierarchy according to Cryptoki
 // - Storage

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,13 +68,12 @@ impl Id {
         self.0 < 256
     }
 
-    /// skips leading zeros
     pub fn hex(&self) -> Bytes<32> {
         const HEX_CHARS: &[u8] = b"0123456789abcdef";
         let mut buffer = Bytes::new();
         let array = self.0.to_be_bytes();
 
-        for i in 0 .. array.len() {
+        for i in 0..array.len() {
             buffer.push(HEX_CHARS[(array[i] >> 4) as usize]).unwrap();
             buffer.push(HEX_CHARS[(array[i] & 0xf) as usize]).unwrap();
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,12 +74,7 @@ impl Id {
         let mut buffer = Bytes::new();
         let array = self.0.to_be_bytes();
 
-        for i in 0..array.len() {
-            if array[i] == 0 && i != (array.len() - 1) {
-                // Skip leading zeros.
-                continue;
-            }
-
+        for i in 0 .. array.len() {
             buffer.push(HEX_CHARS[(array[i] >> 4) as usize]).unwrap();
             buffer.push(HEX_CHARS[(array[i] & 0xf) as usize]).unwrap();
         }
@@ -317,7 +312,7 @@ added as payload for that enum variant.
 Backends are called from Service::process() under consideration of the
 selection and ordering the calling client has specified in its ClientId.
 */
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ServiceBackends {
     Software,
     SoftwareAuth,

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -12,13 +12,14 @@ use chacha20::ChaCha8Rng;
 use rand_core::SeedableRng as _;
 
 use crate::{
+    api::{Reply, Request},
     client::mechanisms::{Ed255 as _, P256 as _},
     pipe::TrussedInterchange,
     platform,
     service::Service,
     syscall,
-    types::Location,
-    ClientImplementation, Interchange as _,
+    types::{ClientContext, Location, ServiceBackends},
+    ClientImplementation, Error, Interchange as _,
 };
 
 pub use store::{Filesystem, Ram, StoreProvider};
@@ -131,5 +132,14 @@ unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
 
     fn store(&self) -> Self::S {
         unsafe { self.store.store() }
+    }
+
+    fn platform_reply_to(
+        &mut self,
+        _backend_id: ServiceBackends,
+        _client_id: &mut ClientContext,
+        _request: &Request,
+    ) -> Result<Reply, Error> {
+        Err(Error::RequestNotAvailable)
     }
 }

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use generic_array::typenum::{U16, U512};
-use littlefs2::{const_ram_storage, driver::Storage};
+use littlefs2::{const_ram_storage, consts, driver::Storage};
 
 use crate::{
     store,


### PR DESCRIPTION
This adds the structure to allow multiple service backends. Essentially the client now has the possibility to choose a order-of-dispatch in its `ClientContext`. This is an elementary step towards transparent hardware crypto devices like the se050.

* Extend `ClientId` to be a proper struct and call it make it a `ClientContext` (as the name suggests)
* Fix several concurrency issues during directory traversal using the `ClientContext` instead of a quasi-global
* extend all necessary components and `reply_to` dispatching based on client-chosen service backends  