### PR TITLE
Add P256 HMAC-based key derivation from the supplied data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ default-mechanisms = [
     # "hmac-blake2s",
     "hmac-sha1",
     "hmac-sha256",
+    "hmac-sha256-p256",
 	# For some reason, this breaks Solo 2 firmware
 	# At minimum, this seems to have a huge "block" method
     # "hmac-sha512",
@@ -98,6 +99,7 @@ x255 = []
 hmac-blake2s = ["blake2"]
 hmac-sha1 = []
 hmac-sha256 = []
+hmac-sha256-p256 = []
 hmac-sha512 = []
 p256 = []
 sha256 = []

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -196,6 +196,20 @@ pub trait HmacSha256: CryptoClient {
     }
 }
 
+#[cfg(feature = "hmac-sha256-p256")]
+impl<S: Syscall> HmacSha256P256 for ClientImplementation<S> {}
+
+pub trait HmacSha256P256: CryptoClient {
+    fn hmacsha256p256_derive_key(&mut self, base_key: KeyId, message: &[u8], persistence: Location)
+        -> ClientResult<'_, reply::DeriveKey, Self>
+    {
+        self.derive_key(
+            Mechanism::HmacSha256P256, base_key,
+            Some(MediumData::from_slice(message).map_err(|_| ClientError::DataTooLarge)?),
+            StorageAttributes::new().set_persistence(persistence))
+    }
+}
+
 #[cfg(feature = "hmac-sha512")]
 impl<S: Syscall> HmacSha512 for ClientImplementation<S> {}
 

--- a/src/mechanisms.rs
+++ b/src/mechanisms.rs
@@ -34,6 +34,9 @@ mod hmacsha1;
 pub struct HmacSha256 {}
 mod hmacsha256;
 
+pub struct HmacSha256P256 {}
+mod hmacsha256_p256;
+
 pub struct HmacSha512 {}
 #[cfg(feature = "hmac-sha512")]
 mod hmacsha512;

--- a/src/mechanisms/hmacsha256_p256.rs
+++ b/src/mechanisms/hmacsha256_p256.rs
@@ -1,0 +1,95 @@
+#[cfg(feature = "hmac-sha256-p256")]
+use crate::api::*;
+#[cfg(feature = "hmac-sha256-p256")]
+use crate::error::Error;
+use crate::service::*;
+#[cfg(feature = "hmac-sha256-p256")]
+use hmac::crypto_mac::InvalidKeyLength;
+
+#[cfg(feature = "hmac-sha256-p256")]
+use hmac::{Hmac, Mac, NewMac};
+#[cfg(feature = "hmac-sha256-p256")]
+type HmacSha256 = Hmac<sha2::Sha256>;
+
+#[cfg(feature = "hmac-sha256-p256")]
+fn get_hmac(key: &[u8]) -> Result<HmacSha256, InvalidKeyLength> {
+    let mac = HmacSha256::new_from_slice(&key.as_ref())?;
+    Ok(mac)
+}
+
+#[cfg(feature = "hmac-sha256-p256")]
+impl DeriveKey for super::HmacSha256P256 {
+    #[inline(never)]
+    fn derive_key(
+        keystore: &mut impl Keystore,
+        request: &request::DeriveKey,
+    ) -> Result<reply::DeriveKey, Error> {
+        //TODO: identical as HmacSha256 implementation, but stores key as Kind::P256
+        let key_id = request.base_key;
+        let material_raw = keystore
+            .load_key(key::Secrecy::Secret, None, &key_id)?
+            .material;
+        let shared_secret = material_raw.as_slice();
+        let mut mac = get_hmac(&shared_secret[..32]).map_err(|_| Error::InternalError)?;
+
+        if let Some(additional_data) = &request.additional_data {
+            mac.update(&additional_data);
+        }
+        let derived_key: [u8; 32] = mac
+            .finalize()
+            .into_bytes()
+            .try_into()
+            .map_err(|_| Error::InternalError)?;
+
+        let key_id = keystore.store_key(
+            request.attributes.persistence,
+            key::Secrecy::Secret,
+            key::Kind::P256,
+            &derived_key,
+        )?;
+
+        Ok(reply::DeriveKey { key: key_id })
+    }
+}
+
+#[cfg(not(feature = "hmac-sha256-p256"))]
+impl DeriveKey for super::HmacSha256P256 {}
+
+#[cfg(feature = "hmac-sha256-p256")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hmac() {
+        let expected1 = [
+            111, 176, 100, 219, 221, 79, 157, 119, 246, 23, 196, 57, 85, 6, 201, 243, 17, 168, 135,
+            139, 137, 129, 236, 115, 170, 209, 159, 98, 111, 80, 173, 36,
+        ];
+        let data1 = b"test data 1";
+        let res1: [u8; 32] = get_hmac(&data1[..])
+            .unwrap()
+            .finalize()
+            .into_bytes()
+            .try_into()
+            .unwrap();
+        assert_eq!(res1, expected1);
+
+        let data2 = b"test data 2";
+        let res2: [u8; 32] = get_hmac(&data2[..])
+            .unwrap()
+            .finalize()
+            .into_bytes()
+            .try_into()
+            .unwrap();
+        assert_ne!(res1, res2);
+
+        let res3: [u8; 32] = get_hmac(&data2[..])
+            .unwrap()
+            .finalize()
+            .into_bytes()
+            .try_into()
+            .unwrap();
+        assert_eq!(res3, res2);
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -166,6 +166,7 @@ impl<P: Platform> ServiceResources<P> {
                     Mechanism::HmacBlake2s => mechanisms::HmacBlake2s::derive_key(keystore, request),
                     Mechanism::HmacSha1 => mechanisms::HmacSha1::derive_key(keystore, request),
                     Mechanism::HmacSha256 => mechanisms::HmacSha256::derive_key(keystore, request),
+                    Mechanism::HmacSha256P256 => mechanisms::HmacSha256P256::derive_key(keystore, request),
                     Mechanism::HmacSha512 => mechanisms::HmacSha512::derive_key(keystore, request),
                     Mechanism::Ed255 => mechanisms::Ed255::derive_key(keystore, request),
                     Mechanism::P256 => mechanisms::P256::derive_key(keystore, request),

--- a/src/types.rs
+++ b/src/types.rs
@@ -488,6 +488,7 @@ pub enum Mechanism {
     HmacBlake2s,
     HmacSha1,
     HmacSha256,
+    HmacSha256P256,
     HmacSha512,
     // P256XSha256,
     P256,


### PR DESCRIPTION
Based on the HmacSha256 implementation - the only difference is, that the result is stored as a P256 key, instead of a shared variant.

As discussed, it would be best in the future to introduce shared implementation across different combinations of hash and resulting key algorithms.

Requesting for comments / solution suggestions.

-----

Improvement ideas:
- Provide a way to connect multiple mechanisms together, without copying the implementation like in this case.

Current downsides:
- supplied implementation is almost a verbatim copy of `HmacSha256`.


-----

To do:
- [ ] change the algorithm to seed-based Ed25519 instead
- [ ] make sure the generated keys are correct - apply proper checks

-----

Note: this PR will be soon obsolete, in a favor of using backend and extension based implementation