### PR TITLE
change *KeyStore<P> to KeyStore<S: Store>

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -97,7 +97,7 @@ impl<P: Platform> ServiceResources<P> {
         let full_store = self.platform.store();
 
         // prepare keystore, bound to client_id, for cryptographic calls
-        let mut keystore: ClientKeystore<P> = ClientKeystore::new(
+        let mut keystore: ClientKeystore<P::S> = ClientKeystore::new(
             client_id.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
@@ -141,7 +141,7 @@ impl<P: Platform> ServiceResources<P> {
             },
 
             Request::Attest(request) => {
-                let mut attn_keystore: ClientKeystore<P> = ClientKeystore::new(
+                let mut attn_keystore: ClientKeystore<P::S> = ClientKeystore::new(
                     PathBuf::from("attn"),
                     self.rng().map_err(|_| Error::EntropyMalfunction)?,
                     full_store,

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -4,24 +4,24 @@ use littlefs2::path::PathBuf;
 use crate::{
     error::{Error, Result},
     key,
-    store::{self, Store as _},
+    store::{self, Store},
     types::{KeyId, Location},
-    Bytes, Platform,
+    Bytes,
 };
 
 pub type ClientId = littlefs2::path::PathBuf;
 
-pub struct ClientKeystore<P>
+pub struct ClientKeystore<S>
 where
-    P: Platform,
+    S: Store,
 {
     client_id: ClientId,
     rng: ChaCha8Rng,
-    store: P::S,
+    store: S,
 }
 
-impl<P: Platform> ClientKeystore<P> {
-    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: P::S) -> Self {
+impl<S: Store> ClientKeystore<S> {
+    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: S) -> Self {
         Self {
             client_id,
             rng,
@@ -67,7 +67,7 @@ pub trait Keystore {
     fn location(&self, secrecy: key::Secrecy, id: &KeyId) -> Option<Location>;
 }
 
-impl<P: Platform> ClientKeystore<P> {
+impl<S: Store> ClientKeystore<S> {
     pub fn generate_key_id(&mut self) -> KeyId {
         KeyId::new(self.rng())
     }
@@ -89,7 +89,7 @@ impl<P: Platform> ClientKeystore<P> {
     }
 }
 
-impl<P: Platform> Keystore for ClientKeystore<P> {
+impl<S: Store> Keystore for ClientKeystore<S> {
     fn rng(&mut self) -> &mut ChaCha8Rng {
         &mut self.rng
     }


### PR DESCRIPTION
* Generic `<P: Platform>` is never needed within `*KeyStore`
* KeyStore only needs `P::S` which is `Store`
* Now consistent with the other `*Store`s (which only use `<S>`)

Just a minor change, mainly for consistency reasons 