### PR TITLE
Relax key kind check in derive_key for hmacsha256

### DIFF
--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -16,7 +16,9 @@ impl DeriveKey for super::HmacSha256 {
         let key_id = request.base_key;
         let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
-            return Err(Error::WrongKeyKind);
+            // We have to disable this check for compatibility with fido-authenticator, see:
+            // https://github.com/solokeys/fido-authenticator/issues/21
+            warn!("derive_key for hmacsha256 called with invalid key kind ({:?})", key.kind);
         }
         let shared_secret = key.material;
 


### PR DESCRIPTION
In #38 [0], we restricted the operations for the hmacsha256 mechanism to symmetric and shared keys.  This breaks fido-authenticator because it uses hmacsha256 derive_key on EC keys [1].  This patch relaxes the restrictions to allow all key kinds.

[0] https://github.com/trussed-dev/trussed/pull/38
[1] https://github.com/solokeys/fido-authenticator/issues/21

cc @sosthene-nitrokey: I can’t add you as a reviewer, but please have a look.