### PR TITLE
Fix virtual platform

### DIFF
--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -108,7 +108,11 @@ impl Filesystem {
             file.set_len(len).expect("failed to set storage file len");
             true
         };
-        Self { internal, format }
+        let fs = Self { internal, format };
+        unsafe {
+            fs.reset();
+        }
+        fs
     }
 }
 
@@ -147,8 +151,18 @@ store!(
     Volatile: VolatileStorage
 );
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug)]
 pub struct Ram {}
+
+impl Default for Ram {
+    fn default() -> Self {
+        let ram = Self {};
+        unsafe {
+            ram.reset();
+        }
+        ram
+    }
+}
 
 impl StoreProvider for Ram {
     type Store = RamStore;

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -51,7 +51,7 @@ impl Storage for FilesystemStorage {
         let mut file = File::open(&self.0).unwrap();
         file.seek(SeekFrom::Start(offset as _)).unwrap();
         let bytes_read = file.read(buffer).unwrap();
-        assert_eq!(bytes_read, buffer.len());
+        assert!(bytes_read <= buffer.len());
         Ok(bytes_read as _)
     }
 


### PR DESCRIPTION
This PR contains two fixes for the virtual platform: relaxing an assertion that was too strict, and making sure that the store is initialized before a service is constructed.