### PR TITLE
Enforce namespace in FilesystemClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed off-by-one error in `RandomBytes` request.
 - Fixed a race condition when iterating over the filesystem in more than one
   client ([#64]).
+- Fixed missing path validation in `Filestore` that allowed clients to escape
+  their namespace ([#65]).
 
 [#64]: https://github.com/trussed-dev/trussed/issues/64
+[#65]: https://github.com/trussed-dev/trussed/issues/65
 
 ## [0.1.0] - 2022-01-26
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,7 @@ pub enum Error {
     FilesystemWriteFailure,
     ImplementationError,
     InternalError,
+    InvalidPath,
     InvalidSerializedKey,
     InvalidSerializationFormat,
     MechanismNotAvailable,

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -1,0 +1,55 @@
+#![cfg(feature = "virt")]
+
+use trussed::{
+    client::{CryptoClient, FilesystemClient},
+    error::Error,
+    syscall, try_syscall,
+    types::{Location, Mechanism, PathBuf, StorageAttributes},
+};
+
+mod client;
+
+#[test]
+fn escape_namespace_parent() {
+    client::get(|client| {
+        let key = syscall!(client.generate_key(Mechanism::P256, StorageAttributes::new())).key;
+
+        // first approach: directly escape namespace
+        let mut path = PathBuf::from("..");
+        path.push(&PathBuf::from("sec"));
+        path.push(&PathBuf::from(key.hex().as_slice()));
+        assert_eq!(
+            try_syscall!(client.read_file(Location::Volatile, path)),
+            Err(Error::InvalidPath),
+        );
+
+        // second approach: start with subdir, then escape namespace
+        let mut path = PathBuf::from("foobar/../..");
+        path.push(&PathBuf::from("sec"));
+        path.push(&PathBuf::from(key.hex().as_slice()));
+        assert_eq!(
+            try_syscall!(client.read_file(Location::Volatile, path)),
+            Err(Error::InvalidPath),
+        );
+
+        // false positive: does not escape namespace but still forbidden
+        let mut path = PathBuf::from("foobar/..");
+        path.push(&PathBuf::from("sec"));
+        path.push(&PathBuf::from(key.hex().as_slice()));
+        assert_eq!(
+            try_syscall!(client.read_file(Location::Volatile, path)),
+            Err(Error::InvalidPath),
+        );
+    })
+}
+
+#[test]
+fn escape_namespace_root() {
+    client::get(|client| {
+        let key = syscall!(client.generate_key(Mechanism::P256, StorageAttributes::new())).key;
+        let mut path = PathBuf::from("/test");
+        path.push(&PathBuf::from("sec"));
+        path.push(&PathBuf::from(key.hex().as_slice()));
+        assert!(try_syscall!(client.read_file(Location::Volatile, path)).is_err());
+    })
+}


### PR DESCRIPTION
This patch adds a check to FilesystemClient that makes sure that clients cannot read out files that belong to other clients or that are not in the data directory for the client.

This is a breaking change as the Error enum is extended.

Fixes https://github.com/trussed-dev/trussed/issues/65