### PR TITLE
Add support for multiple backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added virtual platform in `virt` module.
 - Added methods for creating the client stores to `ServiceResources`.
 - Implemented `unsafe_inject_key` for Aes256Cbc, Ed255, X255, P256.
+- Added support for custom backends in `backend` module.
 
 ### Changed
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,68 @@
+//! Custom backends that can override core request implementations.
+//!
+//! Trussed provides a default implementation for all [`Request`][]s, the core backend.  Runners
+//! can add custom [`Backend`][] implementations using the [`Dispatch`][] trait that can override
+//! the implementation of one or more requests.  The backends used to execute a request can be
+//! selected per client when constructing a client using
+//! [`ClientBuilder::backends`][`crate::client::ClientBuilder::backends`].
+
+use crate::{
+    api::{Reply, Request},
+    error::Error,
+    platform::Platform,
+    service::ServiceResources,
+    types::{ClientContext, Empty},
+};
+
+/// The ID of a backend.
+///
+/// This ID can refer to the core backend provided by the Trussed crate, or to a custom backend
+/// defined by the runner.  The custom ID type is defined by [`Dispatch::BackendId`][].
+pub enum BackendId<I> {
+    Core,
+    Custom(I),
+}
+
+/// A custom backend that can override the core request implementations.
+pub trait Backend<P: Platform> {
+    /// Executes a request using this backend or returns [`Error::RequestNotAvailable`][] if it is
+    /// not supported by this backend.
+    fn request(
+        &mut self,
+        client_ctx: &mut ClientContext,
+        request: &Request,
+        resources: &mut ServiceResources<P>,
+    ) -> Result<Reply, Error>;
+}
+
+/// Dispatches requests to custom backends.
+///
+/// If a runner does not support custom backends, it can use the [`CoreOnly`][] dispatch.
+/// Otherwise it can provide an implementation of this trait that defines which backends are
+/// supported.  The backends that are used to execute a request can be selected when constructing a
+/// client using [`ClientBuilder::backends`][`crate::client::ClientBuilder::backends`].
+pub trait Dispatch<P: Platform> {
+    /// The ID type for the custom backends used by this dispatch implementation.
+    type BackendId: 'static;
+
+    /// Executes a request using a backend or returns [`Error::RequestNotAvailable`][] if it is not
+    /// supported by the backend.
+    fn request(
+        &mut self,
+        backend: &Self::BackendId,
+        ctx: &mut ClientContext,
+        request: &Request,
+        resources: &mut ServiceResources<P>,
+    ) -> Result<Reply, Error> {
+        let _ = (backend, ctx, request, resources);
+        Err(Error::RequestNotAvailable)
+    }
+}
+
+/// Always dispatches to the Trussed core backend.
+#[derive(Debug, Default)]
+pub struct CoreOnly;
+
+impl<P: Platform> Dispatch<P> for CoreOnly {
+    type BackendId = Empty;
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -730,8 +730,7 @@ impl<I: 'static> ClientBuilder<I> {
     ) -> Result<Requester<TrussedInterchange>, Error> {
         let (requester, responder) =
             TrussedInterchange::claim().ok_or(Error::ClientCountExceeded)?;
-        let client_ctx = ClientContext::from(self.id);
-        service.add_endpoint(responder, client_ctx, self.backends)?;
+        service.add_endpoint(responder, self.id, self.backends)?;
         Ok(requester)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -77,11 +77,13 @@
 //!
 use core::{marker::PhantomData, task::Poll};
 
-use interchange::Requester;
+use interchange::{Interchange as _, Requester};
 
 use crate::api::*;
+use crate::backend::{BackendId, Dispatch};
 use crate::error::*;
 use crate::pipe::TrussedInterchange;
+use crate::service::Service;
 use crate::types::*;
 
 pub use crate::platform::Syscall;
@@ -682,6 +684,83 @@ pub trait UiClient: PollClient {
 
     fn wink(&mut self, duration: core::time::Duration) -> ClientResult<'_, reply::Wink, Self> {
         self.request(request::Wink { duration })
+    }
+}
+
+/// Builder for [`ClientImplementation`][].
+///
+/// This builder can be used to select the backends used for the client.  If no backends are used,
+/// [`Service::try_new_client`][], [`Service::try_as_new_client`][] and
+/// [`Service::try_into_new_client`][] can be used directly.
+///
+/// The maximum number of clients that can be created is defined by the `clients-?` features.  If
+/// this number is exceeded, [`Error::ClientCountExceeded`][] is returned.
+pub struct ClientBuilder<I: 'static = Empty> {
+    id: PathBuf,
+    backends: &'static [BackendId<I>],
+}
+
+impl ClientBuilder {
+    /// Creates a new client builder using the given client ID.
+    ///
+    /// Per default, the client does not support backends and always uses the Trussed core
+    /// implementation to execute requests.
+    pub fn new(id: impl Into<PathBuf>) -> Self {
+        Self {
+            id: id.into(),
+            backends: &[],
+        }
+    }
+}
+
+impl<I: 'static> ClientBuilder<I> {
+    /// Selects the backends to use for this client.
+    ///
+    /// If `backends` is empty, the Trussed core implementation is always used.
+    pub fn backends<J: 'static>(self, backends: &'static [BackendId<J>]) -> ClientBuilder<J> {
+        ClientBuilder {
+            id: self.id,
+            backends,
+        }
+    }
+
+    fn create_endpoint<P: Platform, D: Dispatch<P, BackendId = I>>(
+        self,
+        service: &mut Service<P, D>,
+    ) -> Result<Requester<TrussedInterchange>, Error> {
+        let (requester, responder) =
+            TrussedInterchange::claim().ok_or(Error::ClientCountExceeded)?;
+        let client_ctx = ClientContext::from(self.id);
+        service.add_endpoint(responder, client_ctx, self.backends)?;
+        Ok(requester)
+    }
+
+    /// Builds the client using a custom [`Syscall`][] implementation.
+    pub fn build<P: Platform, D: Dispatch<P, BackendId = I>, S: Syscall>(
+        self,
+        service: &mut Service<P, D>,
+        syscall: S,
+    ) -> Result<ClientImplementation<S>, Error> {
+        self.create_endpoint(service)
+            .map(|requester| ClientImplementation::new(requester, syscall))
+    }
+
+    /// Builds the client using a [`Service`][] instance.
+    pub fn build_with_service<P: Platform, D: Dispatch<P, BackendId = I>>(
+        self,
+        mut service: Service<P, D>,
+    ) -> Result<ClientImplementation<Service<P, D>>, Error> {
+        self.create_endpoint(&mut service)
+            .map(|requester| ClientImplementation::new(requester, service))
+    }
+
+    /// Builds the client using a mutable reference to a [`Service`][].
+    pub fn build_with_service_mut<P: Platform, D: Dispatch<P, BackendId = I>>(
+        self,
+        service: &mut Service<P, D>,
+    ) -> Result<ClientImplementation<&mut Service<P, D>>, Error> {
+        self.create_endpoint(service)
+            .map(|requester| ClientImplementation::new(requester, service))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ pub enum Error {
     // our errors
     AeadError,
     CborError,
+    ClientCountExceeded,
     EntropyMalfunction,
     FilesystemReadFailure,
     FilesystemWriteFailure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ generate_macros!();
 pub use interchange::Interchange;
 
 pub mod api;
+pub mod backend;
 pub mod client;
 pub mod config;
 pub mod error;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -7,7 +7,7 @@ use interchange::Responder;
 use crate::api::{Reply, Request};
 use crate::backend::BackendId;
 use crate::error::Error;
-use crate::types::ClientContext;
+use crate::types::Context;
 
 cfg_if::cfg_if! {
 
@@ -72,11 +72,11 @@ cfg_if::cfg_if! {
 // https://xenomai.org/documentation/xenomai-2.4/html/api/group__native__queue.html
 // https://doc.micrium.com/display/osiiidoc/Using+Message+Queues
 
-pub struct ServiceEndpoint<I: 'static> {
+pub struct ServiceEndpoint<I: 'static, C> {
     pub interchange: Responder<TrussedInterchange>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
-    pub client_ctx: ClientContext,
+    pub ctx: Context<C>,
     pub backends: &'static [BackendId<I>],
 }
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -5,6 +5,7 @@
 use interchange::Responder;
 
 use crate::api::{Reply, Request};
+use crate::backend::BackendId;
 use crate::error::Error;
 use crate::types::ClientContext;
 
@@ -71,11 +72,12 @@ cfg_if::cfg_if! {
 // https://xenomai.org/documentation/xenomai-2.4/html/api/group__native__queue.html
 // https://doc.micrium.com/display/osiiidoc/Using+Message+Queues
 
-pub struct ServiceEndpoint {
+pub struct ServiceEndpoint<I: 'static> {
     pub interchange: Responder<TrussedInterchange>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
     pub client_ctx: ClientContext,
+    pub backends: &'static [BackendId<I>],
 }
 
 // pub type ClientEndpoint = Requester<TrussedInterchange>;

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,6 +5,8 @@ use littlefs2::path::PathBuf;
 pub use rand_core::{RngCore, SeedableRng};
 
 use crate::api::*;
+use crate::backend::{BackendId, CoreOnly, Dispatch};
+use crate::client::{ClientBuilder, ClientImplementation};
 use crate::config::*;
 use crate::error::{Error, Result};
 pub use crate::key;
@@ -69,16 +71,18 @@ impl<P: Platform> ServiceResources<P> {
     }
 }
 
-pub struct Service<P>
+pub struct Service<P, D = CoreOnly>
 where
     P: Platform,
+    D: Dispatch<P>,
 {
-    eps: Vec<ServiceEndpoint, { MAX_SERVICE_CLIENTS::USIZE }>,
+    eps: Vec<ServiceEndpoint<D::BackendId>, { MAX_SERVICE_CLIENTS::USIZE }>,
     resources: ServiceResources<P>,
+    dispatch: D,
 }
 
 // need to be able to send crypto service to an interrupt handler
-unsafe impl<P: Platform> Send for Service<P> {}
+unsafe impl<P: Platform, D: Dispatch<P>> Send for Service<P, D> {}
 
 impl<P: Platform> ServiceResources<P> {
     pub fn certstore(&mut self, client_ctx: &ClientContext) -> Result<ClientCertstore<P::S>> {
@@ -657,77 +661,67 @@ impl<P: Platform> ServiceResources<P> {
 
 impl<P: Platform> Service<P> {
     pub fn new(platform: P) -> Self {
+        Self::with_dispatch(platform, Default::default())
+    }
+}
+
+impl<P: Platform, D: Dispatch<P>> Service<P, D> {
+    pub fn with_dispatch(platform: P, dispatch: D) -> Self {
         let resources = ServiceResources::new(platform);
         Self {
             eps: Vec::new(),
             resources,
+            dispatch,
         }
     }
+}
 
+impl<P: Platform> Service<P> {
     /// Add a new client, claiming one of the statically configured
     /// interchange pairs.
-    #[allow(clippy::result_unit_err)]
-    pub fn try_new_client<S: crate::platform::Syscall>(
+    pub fn try_new_client<S: Syscall>(
         &mut self,
         client_id: &str,
         syscall: S,
-    ) -> Result<crate::client::ClientImplementation<S>, ()> {
-        use interchange::Interchange;
-        let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_ctx = ClientContext::from(client_id);
-        self.add_endpoint(responder, client_ctx)
-            .map_err(|_service_endpoint| ())?;
-
-        Ok(crate::client::ClientImplementation::new(requester, syscall))
+    ) -> Result<ClientImplementation<S>, Error> {
+        ClientBuilder::new(client_id).build(self, syscall)
     }
 
     /// Specialization of `try_new_client`, using `self`'s implementation of `Syscall`
     /// (directly call self for processing). This method is only useful for single-threaded
     /// single-app runners.
-    #[allow(clippy::result_unit_err)]
     pub fn try_as_new_client(
         &mut self,
         client_id: &str,
-    ) -> Result<crate::client::ClientImplementation<&mut Service<P>>, ()> {
-        use interchange::Interchange;
-        let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_ctx = ClientContext::from(client_id);
-        self.add_endpoint(responder, client_ctx)
-            .map_err(|_service_endpoint| ())?;
-
-        Ok(crate::client::ClientImplementation::new(requester, self))
+    ) -> Result<ClientImplementation<&mut Self>, Error> {
+        ClientBuilder::new(client_id).build_with_service_mut(self)
     }
 
     /// Similar to [try_as_new_client][Service::try_as_new_client] except that the returning client owns the
     /// Service and is therefore `'static`
-    #[allow(clippy::result_unit_err)]
-    pub fn try_into_new_client(
-        mut self,
-        client_id: &str,
-    ) -> Result<crate::client::ClientImplementation<Service<P>>, ()> {
-        use interchange::Interchange;
-        let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_ctx = ClientContext::from(client_id);
-        self.add_endpoint(responder, client_ctx)
-            .map_err(|_service_endpoint| ())?;
-
-        Ok(crate::client::ClientImplementation::new(requester, self))
+    pub fn try_into_new_client(self, client_id: &str) -> Result<ClientImplementation<Self>, Error> {
+        ClientBuilder::new(client_id).build_with_service(self)
     }
+}
 
-    #[allow(clippy::result_large_err)]
+impl<P: Platform, D: Dispatch<P>> Service<P, D> {
     pub fn add_endpoint(
         &mut self,
         interchange: Responder<TrussedInterchange>,
         client_ctx: impl Into<ClientContext>,
-    ) -> Result<(), ServiceEndpoint> {
+        backends: &'static [BackendId<D::BackendId>],
+    ) -> Result<(), Error> {
         let client_ctx = client_ctx.into();
         if client_ctx.path == PathBuf::from("trussed") {
             panic!("trussed is a reserved client ID");
         }
-        self.eps.push(ServiceEndpoint {
-            interchange,
-            client_ctx,
-        })
+        self.eps
+            .push(ServiceEndpoint {
+                interchange,
+                client_ctx,
+                backends,
+            })
+            .map_err(|_| Error::ClientCountExceeded)
     }
 
     pub fn set_seed_if_uninitialized(&mut self, seed: &[u8; 32]) {
@@ -766,7 +760,24 @@ impl<P: Platform> Service<P> {
                 // #[cfg(test)] println!("service got request: {:?}", &request);
 
                 // resources.currently_serving = ep.client_id.clone();
-                let reply_result = resources.reply_to(&mut ep.client_ctx, &request);
+                let mut reply_result = Err(Error::RequestNotAvailable);
+                if ep.backends.is_empty() {
+                    reply_result = resources.reply_to(&mut ep.client_ctx, &request);
+                } else {
+                    for backend in ep.backends {
+                        reply_result = match backend {
+                            BackendId::Core => resources.reply_to(&mut ep.client_ctx, &request),
+                            BackendId::Custom(id) => {
+                                self.dispatch
+                                    .request(id, &mut ep.client_ctx, &request, resources)
+                            }
+                        };
+
+                        if reply_result != Err(Error::RequestNotAvailable) {
+                            break;
+                        }
+                    }
+                }
 
                 resources
                     .platform
@@ -799,18 +810,20 @@ impl<P: Platform> Service<P> {
     }
 }
 
-impl<P> crate::client::Syscall for &mut Service<P>
+impl<P, D> crate::client::Syscall for &mut Service<P, D>
 where
     P: Platform,
+    D: Dispatch<P>,
 {
     fn syscall(&mut self) {
         self.process();
     }
 }
 
-impl<P> crate::client::Syscall for Service<P>
+impl<P, D> crate::client::Syscall for Service<P, D>
 where
     P: Platform,
+    D: Dispatch<P>,
 {
     fn syscall(&mut self) {
         self.process();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -187,7 +187,7 @@ macro_rules! setup {
         let test_client_id = "TEST";
 
         assert!(trussed
-            .add_endpoint(test_trussed_responder, test_client_id)
+            .add_endpoint(test_trussed_responder, test_client_id, &[])
             .is_ok());
 
         trussed.set_seed_if_uninitialized(&$seed);

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,10 @@ use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 pub use crate::client::FutureResult;
 pub use crate::platform::Platform;
 
+/// An empty enum that cannot be constructed.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Empty {}
+
 /// The ID of a Trussed object.
 ///
 /// Apart from the 256 "special" IDs, generated as a random 128-bit number,

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "virt")]
+
+use trussed::{
+    api::{reply::ReadFile, Reply, Request},
+    backend::{self, Backend as _, BackendId},
+    client::FilesystemClient as _,
+    error::Error,
+    platform,
+    service::{Service, ServiceResources},
+    types::{ClientContext, Location, Message, PathBuf},
+    virt::{self, Ram},
+    ClientImplementation,
+};
+
+type Platform = virt::Platform<Ram>;
+type Client = ClientImplementation<Service<Platform, Dispatch>>;
+
+const BACKENDS_TEST: &[BackendId<Backend>] = &[BackendId::Custom(Backend::Test), BackendId::Core];
+
+pub enum Backend {
+    Test,
+}
+
+#[derive(Default)]
+struct Dispatch {
+    test: TestBackend,
+}
+
+impl backend::Dispatch<Platform> for Dispatch {
+    type BackendId = Backend;
+
+    fn request(
+        &mut self,
+        backend: &Self::BackendId,
+        ctx: &mut ClientContext,
+        request: &Request,
+        resources: &mut ServiceResources<Platform>,
+    ) -> Result<Reply, Error> {
+        match backend {
+            Backend::Test => self.test.request(ctx, request, resources),
+        }
+    }
+}
+
+#[derive(Default)]
+struct TestBackend;
+
+impl<P: platform::Platform> backend::Backend<P> for TestBackend {
+    fn request(
+        &mut self,
+        _client_ctx: &mut ClientContext,
+        request: &Request,
+        _resources: &mut ServiceResources<P>,
+    ) -> Result<Reply, Error> {
+        match request {
+            Request::ReadFile(_) => {
+                let mut data = Message::new();
+                data.push(0xff).unwrap();
+                Ok(Reply::ReadFile(ReadFile { data }))
+            }
+            _ => Err(Error::RequestNotAvailable),
+        }
+    }
+}
+
+fn run<F: FnOnce(&mut Client)>(backends: &'static [BackendId<Backend>], f: F) {
+    virt::with_platform(Ram::default(), |platform| {
+        platform.run_client_with_backends("test", Dispatch::default(), backends, |mut client| {
+            f(&mut client)
+        })
+    })
+}
+
+#[test]
+fn override_syscall() {
+    let path = PathBuf::from("test");
+    run(&[], |client| {
+        assert!(trussed::try_syscall!(client.read_file(Location::Internal, path.clone())).is_err());
+    });
+    run(BACKENDS_TEST, |client| {
+        assert_eq!(
+            trussed::syscall!(client.read_file(Location::Internal, path.clone())).data,
+            &[0xff]
+        );
+    })
+}


### PR DESCRIPTION
This is a reduced version of https://github.com/trussed-dev/trussed/pull/41 as discussed today.  The main difference is that the service endpoints cannot be configured at runtime (using a syscall), but only during client creation.  This makes the interface much simpler.  I did not convert the backend ID to an integer as originally planned because there is only one remaining struct that uses the backend ID, `ServiceEndpoint`.

Based on https://github.com/trussed-dev/trussed/pull/67