### PR TITLE
Fix formatting and check format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,6 @@ jobs:
         run: cargo test --verbose --features virt
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
+      - name: Check formatting
+        run: cargo fmt -- --check
+        if: matrix.target == 'x86_64-unknown-linux-gnu'

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -18,7 +18,10 @@ impl DeriveKey for super::HmacSha256 {
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
             // We have to disable this check for compatibility with fido-authenticator, see:
             // https://github.com/solokeys/fido-authenticator/issues/21
-            warn!("derive_key for hmacsha256 called with invalid key kind ({:?})", key.kind);
+            warn!(
+                "derive_key for hmacsha256 called with invalid key kind ({:?})",
+                key.kind
+            );
         }
         let shared_secret = key.material;
 


### PR DESCRIPTION
This patch fixes a formatting error and adds a check to the CI that runs `cargo fmt -- --check`.