### PR TITLE
Make public API more stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `littlefs2` to 0.4.0.
 - Made `Request`, `Reply`, `Error`, `Context`, `CoreContext`, `Mechanism`,
   `ui::Status` non-exhaustive.
+- Made `postcard_deserialize`, `postcard_serialize` and
+  `postcard_serialize_bytes` private.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade the `interchange` dependency to version 0.3.0 ([#99][])
   - As a consequence the type `pipe::TrussedInterchange` becomes a const`pipe::TRUSSED_INTERCHANGE`
 - Updated `littlefs2` to 0.4.0.
+- Made `Request`, `Reply`, `Error`, `Context`, `CoreContext`, `Mechanism`,
+  `ui::Status` non-exhaustive.
 
 ### Fixed
 

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -3,6 +3,7 @@ macro_rules! generate_enums {
 
     #[derive(Clone, Eq, PartialEq, Debug)]
     #[allow(clippy::large_enum_variant)]
+    #[non_exhaustive]
     pub enum Request {
         DummyRequest, // for testing
         $(
@@ -13,6 +14,7 @@ macro_rules! generate_enums {
 
     #[derive(Clone, Eq, PartialEq, Debug)]
     #[allow(clippy::large_enum_variant)]
+    #[non_exhaustive]
     pub enum Reply {
         DummyReply, // for testing
         $(

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum Error {
     // cryptoki errors
     HostMemory = 0x0000_0002,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,12 @@ pub use error::Error;
 pub use platform::Platform;
 pub use service::Service;
 
-pub use cbor_smol::{cbor_deserialize, cbor_serialize, cbor_serialize_bytes};
+pub use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
 pub use heapless_bytes::Bytes;
-pub use postcard::{from_bytes as postcard_deserialize, to_slice as postcard_serialize};
 
-pub fn postcard_serialize_bytes<T: serde::Serialize, const N: usize>(
+pub(crate) use postcard::from_bytes as postcard_deserialize;
+
+pub(crate) fn postcard_serialize_bytes<T: serde::Serialize, const N: usize>(
     object: &T,
 ) -> postcard::Result<Bytes<N>> {
     let vec = postcard::to_vec(object)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,6 +170,7 @@ pub mod ui {
     // TODO: Consider whether a simple "language" to specify "patterns"
     // makes sense, vs. "semantic" indications with platform-specific implementation
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+    #[non_exhaustive]
     pub enum Status {
         Idle,
         WaitingForUserPresence,
@@ -242,6 +243,7 @@ pub mod consent {
 /// The context stores the state used by the standard syscall implementations, see
 /// [`CoreContext`][].  Additionally, backends can define a custom context for their syscall
 /// implementations.
+#[non_exhaustive]
 pub struct Context<B> {
     pub core: CoreContext,
     pub backends: B,
@@ -260,6 +262,7 @@ impl<B: Default> From<CoreContext> for Context<B> {
 // currently has. Trussed currently uses it to choose the client-specific
 // subtree in the filesystem (see docs in src/store.rs) and to maintain
 // the walker state of the directory traversal syscalls.
+#[non_exhaustive]
 pub struct CoreContext {
     pub path: PathBuf,
     pub read_dir_state: Option<ReadDirState>,
@@ -545,6 +548,7 @@ impl Default for StorageAttributes {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Mechanism {
     Aes256Cbc,
     Chacha8Poly1305,


### PR DESCRIPTION
This PR contains two changes that make the public API more robust:
- Marking enums like `Error`, `Response`, `Reply` and `Mechanism` as non-exhaustive makes it possible to add features without breaking compatibility.
- Removing re-exports of the serialization functions from `cbor_smol` and `postcard` gives us more flexibility to change these implementation details.

Fixes https://github.com/trussed-dev/trussed/issues/62