### PR TITLE
Simplify client code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 // use crate::api::Reply;
 // use crate::client::RawClient;
 
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u32)]


### PR DESCRIPTION
This PR refactors `client.rs` to simplify the code a bit.