### PR TITLE
Make all features compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Build
         run: cargo build --verbose --target ${{ matrix.target }}
 
+      - name: Check all features and targets
+        run: cargo check --all-features --all-targets
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+
       - name: Run tests
         run: cargo test --verbose --features virt
         if: matrix.target == 'x86_64-unknown-linux-gnu'

--- a/src/mechanisms/hmacblake2s.rs
+++ b/src/mechanisms/hmacblake2s.rs
@@ -13,8 +13,7 @@ impl DeriveKey for super::HmacBlake2s {
         use hmac::{Hmac, Mac, NewMac};
         type HmacBlake2s = Hmac<blake2::Blake2s>;
 
-        let key_id = request.base_key.object_id;
-        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &request.base_key)?;
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
             return Err(Error::WrongKeyKind);
         }
@@ -31,16 +30,14 @@ impl DeriveKey for super::HmacBlake2s {
             .into_bytes()
             .try_into()
             .map_err(|_| Error::InternalError)?;
-        let key_id = keystore.store_key(
+        let key = keystore.store_key(
             request.attributes.persistence,
             key::Secrecy::Secret,
             key::Kind::Symmetric(32),
             &derived_key,
         )?;
 
-        Ok(reply::DeriveKey {
-            key: ObjectHandle { object_id: key_id },
-        })
+        Ok(reply::DeriveKey { key })
     }
 }
 
@@ -52,8 +49,7 @@ impl Sign for super::HmacBlake2s {
         use hmac::{Hmac, Mac, NewMac};
         type HmacBlake2s = Hmac<Blake2s>;
 
-        let key_id = request.key.object_id;
-        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &request.key)?;
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
             return Err(Error::WrongKeyKind);
         }

--- a/src/mechanisms/hmacsha512.rs
+++ b/src/mechanisms/hmacsha512.rs
@@ -13,31 +13,28 @@ impl DeriveKey for super::HmacSha512 {
         use hmac::{Hmac, Mac, NewMac};
         type HmacSha512 = Hmac<sha2::Sha512>;
 
-        let key_id = request.base_key.object_id;
-        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &request.base_key)?;
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
             return Err(Error::WrongKeyKind);
         }
         let shared_secret = key.material;
 
         let mut mac =
-            HmacSha512::new_varkey(&shared_secret.as_ref()).map_err(|_| Error::InternalError)?;
+            HmacSha512::new_from_slice(shared_secret.as_ref()).map_err(|_| Error::InternalError)?;
 
         if let Some(additional_data) = &request.additional_data {
             mac.update(&additional_data);
         }
         let mut derived_key = [0u8; 64];
         derived_key.copy_from_slice(&mac.finalize().into_bytes()); //.try_into().map_err(|_| Error::InternalError)?;
-        let key_id = keystore.store_key(
+        let key = keystore.store_key(
             request.attributes.persistence,
             key::Secrecy::Secret,
             key::Kind::Symmetric(64),
             &derived_key,
         )?;
 
-        Ok(reply::DeriveKey {
-            key: ObjectHandle { object_id: key_id },
-        })
+        Ok(reply::DeriveKey { key })
     }
 }
 
@@ -49,15 +46,14 @@ impl Sign for super::HmacSha512 {
         use sha2::Sha512;
         type HmacSha512 = Hmac<Sha512>;
 
-        let key_id = request.key.object_id;
-        let key = keystore.load_key(key::Secrecy::Secret, None, &key_id)?;
+        let key = keystore.load_key(key::Secrecy::Secret, None, &request.key)?;
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
             return Err(Error::WrongKeyKind);
         }
         let shared_secret = key.material;
 
-        let mut mac =
-            HmacSha512::new_varkey(&shared_secret.as_ref()).map_err(|_| Error::InternalError)?;
+        let mut mac = HmacSha512::new_from_slice(&shared_secret.as_ref())
+            .map_err(|_| Error::InternalError)?;
 
         mac.update(&request.message);
         let result = mac.finalize();

--- a/src/service/attest.rs
+++ b/src/service/attest.rs
@@ -21,13 +21,13 @@ use crate::{
 #[cfg(not(feature = "test-attestation-cert-ids"))]
 pub const ED255_ATTN_KEY: KeyId = KeyId::from_special(1);
 #[cfg(feature = "test-attestation-cert-ids")]
-pub const ED255_ATTN_KEY: KeyId = KeyId(Id(u128::from_be_bytes([
+pub const ED255_ATTN_KEY: KeyId = KeyId(crate::types::Id(u128::from_be_bytes([
     0x12, 0xd2, 0xa7, 0xe4, 0x03, 0x55, 0x21, 0x42, 0x99, 0xf1, 0x57, 0x34, 0xc5, 0xd7, 0xd0, 0xe7,
 ])));
 #[cfg(not(feature = "test-attestation-cert-ids"))]
 pub const P256_ATTN_KEY: KeyId = KeyId::from_special(2);
 #[cfg(feature = "test-attestation-cert-ids")]
-pub const P256_ATTN_KEY: KeyId = KeyId(Id(u128::from_be_bytes([
+pub const P256_ATTN_KEY: KeyId = KeyId(crate::types::Id(u128::from_be_bytes([
     0xc8, 0xd6, 0x77, 0xa3, 0x93, 0x46, 0xc9, 0x8f, 0xc8, 0x5a, 0xb0, 0x5d, 0x29, 0xc5, 0x75, 0x32,
 ])));
 


### PR DESCRIPTION
This patch fixes compilation issues in non-default features so that we can compile Trussed with `--all-features`.