### PR TITLE
Increase size of file writing

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -279,8 +279,8 @@ pub mod request {
         WriteFile:
           - location: Location
           - path: PathBuf
-          - data: Message
           - user_attribute: Option<UserAttribute>
+          - data: LargeMessage
 
         UnsafeInjectKey:
           - mechanism: Mechanism        // -> implies key type
@@ -339,7 +339,7 @@ pub mod request {
 
         WriteCertificate:
           - location: Location
-          - der: Message
+          - der: LargeMessage
 
         SerdeExtension:
           - id: u8
@@ -429,7 +429,7 @@ pub mod reply {
           - entry: Option<DirEntry>
 
         ReadFile:
-          - data: Message
+          - data: LargeMessage
 
         Metadata:
           - metadata: Option<crate::types::Metadata>
@@ -490,7 +490,7 @@ pub mod reply {
         DeleteCertificate:
 
         ReadCertificate:
-          - der: Message
+          - der: LargeMessage
 
         WriteCertificate:
           - id: CertId

--- a/src/api.rs
+++ b/src/api.rs
@@ -227,7 +227,6 @@ pub mod request {
         ReadDirFilesFirst:
           - location: Location
           - dir: PathBuf
-          - user_attribute: Option<UserAttribute>
 
         ReadDirFilesNext:
 
@@ -279,7 +278,6 @@ pub mod request {
         WriteFile:
           - location: Location
           - path: PathBuf
-          - user_attribute: Option<UserAttribute>
           - data: LargeMessage
 
         UnsafeInjectKey:

--- a/src/client.rs
+++ b/src/client.rs
@@ -258,7 +258,7 @@ pub trait CertificateClient: PollClient {
         location: Location,
         der: &[u8],
     ) -> ClientResult<'_, reply::WriteCertificate, Self> {
-        let der = Message::from_slice(der).map_err(|_| ClientError::DataTooLarge)?;
+        let der = LargeMessage::from_slice(der).map_err(|_| ClientError::DataTooLarge)?;
         self.request(request::WriteCertificate { location, der })
     }
 }
@@ -650,7 +650,7 @@ pub trait FilesystemClient: PollClient {
         &mut self,
         location: Location,
         path: PathBuf,
-        data: Message,
+        data: LargeMessage,
         user_attribute: Option<UserAttribute>,
     ) -> ClientResult<'_, reply::WriteFile, Self> {
         self.request(request::WriteFile {

--- a/src/client.rs
+++ b/src/client.rs
@@ -577,13 +577,8 @@ pub trait FilesystemClient: PollClient {
         &mut self,
         location: Location,
         dir: PathBuf,
-        user_attribute: Option<UserAttribute>,
     ) -> ClientResult<'_, reply::ReadDirFilesFirst, Self> {
-        self.request(request::ReadDirFilesFirst {
-            dir,
-            location,
-            user_attribute,
-        })
+        self.request(request::ReadDirFilesFirst { dir, location })
     }
 
     fn read_dir_files_next(&mut self) -> ClientResult<'_, reply::ReadDirFilesNext, Self> {
@@ -651,13 +646,11 @@ pub trait FilesystemClient: PollClient {
         location: Location,
         path: PathBuf,
         data: LargeMessage,
-        user_attribute: Option<UserAttribute>,
     ) -> ClientResult<'_, reply::WriteFile, Self> {
         self.request(request::WriteFile {
             location,
             path,
             data,
-            user_attribute,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use littlefs2::consts;
 pub type MAX_APPLICATION_NAME_LENGTH = consts::U256;
 pub const MAX_LONG_DATA_LENGTH: usize = 1024;
 pub const MAX_MESSAGE_LENGTH: usize = 1024;
+pub const MAX_LARGE_MESSAGE_LENGTH: usize = 2048;
 pub type MAX_OBJECT_HANDLES = consts::U16;
 pub type MAX_LABEL_LENGTH = consts::U256;
 pub const MAX_MEDIUM_DATA_LENGTH: usize = 256;

--- a/src/service.rs
+++ b/src/service.rs
@@ -378,7 +378,7 @@ impl<P: Platform> ServiceResources<P> {
             }
 
             Request::ReadDirFilesFirst(request) => {
-                let maybe_data = match filestore.read_dir_files_first(&request.dir, request.location, request.user_attribute.clone())? {
+                let maybe_data = match filestore.read_dir_files_first(&request.dir, request.location)? {
                     Some((data, state)) => {
                         ctx.read_dir_files_state = Some(state);
                         data

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -528,12 +528,7 @@ fn filesystem() {
 
     let data = Bytes::from_slice(&[0; 20]).unwrap();
     block!(client
-        .write_file(
-            Location::Internal,
-            PathBuf::from("test_file"),
-            data.clone(),
-            None
-        )
+        .write_file(Location::Internal, PathBuf::from("test_file"), data.clone())
         .expect("no client error"))
     .expect("no errors");
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -532,7 +532,7 @@ fn filesystem() {
             Location::Internal,
             PathBuf::from("test_file"),
             data.clone(),
-            None,
+            None
         )
         .expect("no client error"))
     .expect("no errors");

--- a/src/types.rs
+++ b/src/types.rs
@@ -616,5 +616,3 @@ pub enum SignatureSerialization {
     Raw,
     // Sec1,
 }
-
-pub type UserAttribute = Bytes<MAX_USER_ATTRIBUTE_LENGTH>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -589,6 +589,7 @@ pub type ShortData = Bytes<MAX_SHORT_DATA_LENGTH>;
 
 pub type Message = Bytes<MAX_MESSAGE_LENGTH>;
 pub type SerializedKey = Bytes<MAX_KEY_MATERIAL_LENGTH>;
+pub type LargeMessage = Bytes<MAX_LARGE_MESSAGE_LENGTH>;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum KeySerialization {

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -7,7 +7,7 @@ use trussed::{
     error::Error,
     platform,
     service::{Service, ServiceResources},
-    types::{Context, CoreContext, Location, Message, PathBuf},
+    types::{Context, CoreContext, LargeMessage, Location, PathBuf},
     virt::{self, Ram},
     ClientImplementation,
 };
@@ -61,7 +61,7 @@ impl backend::Backend for TestBackend {
     ) -> Result<Reply, Error> {
         match request {
             Request::ReadFile(_) => {
-                let mut data = Message::new();
+                let mut data = LargeMessage::new();
                 data.push(0xff).unwrap();
                 Ok(Reply::ReadFile(ReadFile { data }))
             }

--- a/tests/virt.rs
+++ b/tests/virt.rs
@@ -24,7 +24,7 @@ fn run_test(data: u8) {
 
         // ensure that no other client is messing with our filesystem
         while syscall!(client.uptime()).uptime < Duration::from_secs(1) {
-            syscall!(client.write_file(location, path.clone(), write_data.clone(), None));
+            syscall!(client.write_file(location, path.clone(), write_data.clone()));
             let read_data = syscall!(client.read_file(location, path.clone())).data;
             assert_eq!(write_data, read_data);
         }


### PR DESCRIPTION
The increased size of files is a requirement for  PIV, 1kB certificates are too small. This commit also removes the `user_attribute` field that was never read anyway. This avoids increasing the total size of the interchange

Both changes are breaking changes:
- Changing the messages size for the read and write requests can cause compilation error for code that depends on the length of the `heapless` arrays
- Removing `user_attribute` will require changing every call to the `read_file` and `write_methods` to remove the `None`.