### PR TITLE
Replace From<Reply> with TryFrom<Reply> in impl_reply

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,6 @@
 //! [pkcs11-headers]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/cs01/include/pkcs11-v3.0/
 
 use crate::types::*;
-use core::hint::unreachable_unchecked;
 use core::time::Duration;
 
 #[macro_use]

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -79,21 +79,13 @@ macro_rules! impl_reply {
         )*
     }
 
-    // impl core::convert::TryFrom<Reply> for $reply {
-    //     type Error = ();
-    //     fn try_from(reply: Reply) -> Result<reply::$reply, Self::Error> {
-    //         match reply {
-    //             Reply::$reply(reply) => Ok(reply),
-    //             _ => Err(()),
-    //         }
-    //     }
-    // }
+    impl ::core::convert::TryFrom<$crate::api::Reply> for $reply {
+        type Error = $crate::error::Error;
 
-    impl From<Reply> for $reply {
-        fn from(reply: Reply) -> reply::$reply {
+        fn try_from(reply: $crate::api::Reply) -> ::core::result::Result<Self, Self::Error> {
             match reply {
-                Reply::$reply(reply) => reply,
-                _ => { unsafe { unreachable_unchecked() } }
+                $crate::api::Reply::$reply(reply) => Ok(reply),
+                _ => Err(Self::Error::InvalidReply),
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,7 @@ pub enum Error {
     FilesystemWriteFailure,
     ImplementationError,
     InternalError,
+    InvalidReply,
     InvalidSerializedKey,
     InvalidSerializationFormat,
     MechanismNotAvailable,


### PR DESCRIPTION
Previously, we would just trigger undefined behavior (core::hint::unreachable_unchecked) if there was a mismatch between the request and reply types for a Trussed syscall.  With this patch, we return an error instead.

Fixes https://github.com/trussed-dev/trussed/issues/84