### PR TITLE
Introduce type-based linking of requests and replies

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -105,11 +105,11 @@ generate_enums! {
 }
 
 pub trait RequestData: Into<Request> + TryFrom<Request, Error = crate::Error> {
-    type CorrespondingReply: ReplyData<CorrespondingRequest = Self>;
+    type Reply: ReplyData<Request = Self>;
 }
 
 pub trait ReplyData: Into<Reply> + TryFrom<Reply, Error = crate::Error> {
-    type CorrespondingRequest: RequestData<CorrespondingReply = Self>;
+    type Request: RequestData<Reply = Self>;
 }
 
 pub mod request {

--- a/src/api.rs
+++ b/src/api.rs
@@ -104,12 +104,12 @@ generate_enums! {
     DebugDumpStore: 0x79
 }
 
-pub trait RequestData: Into<Request> + TryFrom<Request, Error = crate::Error> {
-    type Reply: ReplyData<Request = Self>;
+pub trait RequestVariant: Into<Request> + TryFrom<Request, Error = crate::Error> {
+    type Reply: ReplyVariant<Request = Self>;
 }
 
-pub trait ReplyData: Into<Reply> + TryFrom<Reply, Error = crate::Error> {
-    type Request: RequestData<Reply = Self>;
+pub trait ReplyVariant: Into<Reply> + TryFrom<Reply, Error = crate::Error> {
+    type Request: RequestVariant<Reply = Self>;
 }
 
 pub mod request {

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,6 @@
 //! [pkcs11-headers]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/cs01/include/pkcs11-v3.0/
 
 use crate::types::*;
-use core::hint::unreachable_unchecked;
 use core::time::Duration;
 
 #[macro_use]
@@ -103,6 +102,14 @@ generate_enums! {
     // Other //
     ///////////
     DebugDumpStore: 0x79
+}
+
+pub trait RequestData: Into<Request> + TryFrom<Request, Error = crate::Error> {
+    type CorrespondingReply: ReplyData<CorrespondingRequest = Self>;
+}
+
+pub trait ReplyData: Into<Reply> + TryFrom<Reply, Error = crate::Error> {
+    type CorrespondingRequest: RequestData<CorrespondingReply = Self>;
 }
 
 pub mod request {

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -61,6 +61,19 @@ macro_rules! impl_request {
             Self::$request(request)
         }
     }
+    impl core::convert::TryFrom<Request> for $request {
+        type Error = crate::Error;
+        fn try_from(request: Request) -> Result<request::$request, Self::Error> {
+            match request {
+                Request::$request(request) => Ok(request),
+                _ => Err(crate::Error::InternalError),
+            }
+        }
+    }
+
+    impl RequestData for $request {
+        type CorrespondingReply = reply::$request;
+    }
 
     )*}
 }
@@ -79,23 +92,24 @@ macro_rules! impl_reply {
         )*
     }
 
-    // impl core::convert::TryFrom<Reply> for $reply {
-    //     type Error = ();
-    //     fn try_from(reply: Reply) -> Result<reply::$reply, Self::Error> {
-    //         match reply {
-    //             Reply::$reply(reply) => Ok(reply),
-    //             _ => Err(()),
-    //         }
-    //     }
-    // }
-
-    impl From<Reply> for $reply {
-        fn from(reply: Reply) -> reply::$reply {
+    impl core::convert::TryFrom<Reply> for $reply {
+        type Error = crate::Error;
+        fn try_from(reply: Reply) -> Result<reply::$reply, Self::Error> {
             match reply {
-                Reply::$reply(reply) => reply,
-                _ => { unsafe { unreachable_unchecked() } }
+                Reply::$reply(reply) => Ok(reply),
+                _ => Err(crate::Error::InternalError),
             }
         }
+    }
+
+    impl core::convert::From<$reply> for Reply {
+        fn from(reply: $reply) -> Reply {
+            Reply::$reply(reply)
+        }
+    }
+
+    impl ReplyData for $reply {
+        type CorrespondingRequest = request::$reply;
     }
 
     )*}

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -71,7 +71,7 @@ macro_rules! impl_request {
         }
     }
 
-    impl RequestData for $request {
+    impl RequestVariant for $request {
         type Reply = reply::$request;
     }
 
@@ -108,7 +108,7 @@ macro_rules! impl_reply {
         }
     }
 
-    impl ReplyData for $reply {
+    impl ReplyVariant for $reply {
         type Request = request::$reply;
     }
 

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -72,7 +72,7 @@ macro_rules! impl_request {
     }
 
     impl RequestData for $request {
-        type CorrespondingReply = reply::$request;
+        type Reply = reply::$request;
     }
 
     )*}
@@ -109,7 +109,7 @@ macro_rules! impl_reply {
     }
 
     impl ReplyData for $reply {
-        type CorrespondingRequest = request::$reply;
+        type Request = request::$reply;
     }
 
     )*}

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,7 +110,7 @@ impl<S: Syscall> Client for ClientImplementation<S> {}
 
 /// Lowest level interface, use one of the higher level ones.
 pub trait PollClient {
-    fn request<Rq: RequestData>(&mut self, req: Rq) -> ClientResult<'_, Rq::Reply, Self>;
+    fn request<Rq: RequestVariant>(&mut self, req: Rq) -> ClientResult<'_, Rq::Reply, Self>;
     fn poll(&mut self) -> Poll<Result<Reply, Error>>;
 }
 
@@ -124,7 +124,7 @@ where
 
 impl<'c, T, C> FutureResult<'c, T, C>
 where
-    T: ReplyData,
+    T: ReplyVariant,
     C: PollClient,
 {
     pub fn new(client: &'c mut C) -> Self {
@@ -207,7 +207,7 @@ where
     }
 
     // call with any of `crate::api::request::*`
-    fn request<Rq: RequestData>(&mut self, req: Rq) -> ClientResult<'_, Rq::Reply, Self> {
+    fn request<Rq: RequestVariant>(&mut self, req: Rq) -> ClientResult<'_, Rq::Reply, Self> {
         // TODO: handle failure
         // TODO: fail on pending (non-canceled) request)
         if self.pending.is_some() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,10 +110,7 @@ impl<S: Syscall> Client for ClientImplementation<S> {}
 
 /// Lowest level interface, use one of the higher level ones.
 pub trait PollClient {
-    fn request<Rq: RequestData>(
-        &mut self,
-        req: Rq,
-    ) -> ClientResult<'_, Rq::CorrespondingReply, Self>;
+    fn request<Rq: RequestData>(&mut self, req: Rq) -> ClientResult<'_, Rq::Reply, Self>;
     fn poll(&mut self) -> Poll<Result<Reply, Error>>;
 }
 
@@ -210,10 +207,7 @@ where
     }
 
     // call with any of `crate::api::request::*`
-    fn request<Rq: RequestData>(
-        &mut self,
-        req: Rq,
-    ) -> ClientResult<'_, Rq::CorrespondingReply, Self> {
+    fn request<Rq: RequestData>(&mut self, req: Rq) -> ClientResult<'_, Rq::Reply, Self> {
         // TODO: handle failure
         // TODO: fail on pending (non-canceled) request)
         if self.pending.is_some() {


### PR DESCRIPTION
This ensures that `PollClient::request` always matches the correct Request and Reply

This patch also fixes https://github.com/trussed-dev/trussed/issues/84 and replaces the `From` that used `unreachable_unchecked` with `TryFrom`.

The main additions are the traits:

```rust
pub trait RequestData: Into<Request> + TryFrom<Request, Error = crate::Error> {
    type CorrespondingReply: ReplyData<CorrespondingRequest = Self>;
}

pub trait ReplyData: Into<Reply> + TryFrom<Reply, Error = crate::Error> {
    type CorrespondingRequest: RequestData<CorrespondingReply = Self>;
}
```

And PollClient's `request` becomes 
```rust
// old
fn request<T: From<Reply>>(&mut self, req: impl Into<Request>) -> ClientResult<'_, T, Self>;
 // new
fn request<Rq: RequestData>(
      &mut self,
      req: Rq,
) -> ClientResult<'_, Rq::CorrespondingReply, Self>;
```

This also showed that the reply type for the `RemoveDir` was incorrect (it returned `RemoveDirAll`) which actually triggered UB is mentionned in #84 