### PR TITLE
Add RSA mechanisms and key serialization format

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -174,7 +174,7 @@ pub mod request {
 
         DeserializeKey:
           - mechanism: Mechanism
-          - serialized_key: Message
+          - serialized_key: SerializedKey
           - format: KeySerialization
           - attributes: StorageAttributes
 
@@ -282,7 +282,7 @@ pub mod request {
 
         UnsafeInjectKey:
           - mechanism: Mechanism        // -> implies key type
-          - raw_key: ShortData
+          - raw_key: SerializedKey
           - attributes: StorageAttributes
           - format: KeySerialization
 
@@ -443,7 +443,7 @@ pub mod reply {
             - bytes: Message
 
         SerializeKey:
-            - serialized_key: Message
+            - serialized_key: SerializedKey
 
         Sign:
             - signature: Signature

--- a/src/client.rs
+++ b/src/client.rs
@@ -353,7 +353,7 @@ pub trait CryptoClient: PollClient {
         attributes: StorageAttributes,
     ) -> ClientResult<'c, reply::DeserializeKey, Self> {
         let serialized_key =
-            Message::from_slice(serialized_key).map_err(|_| ClientError::DataTooLarge)?;
+            SerializedKey::from_slice(serialized_key).map_err(|_| ClientError::DataTooLarge)?;
         self.request(request::DeserializeKey {
             mechanism,
             serialized_key,
@@ -478,7 +478,7 @@ pub trait CryptoClient: PollClient {
     ) -> ClientResult<'_, reply::UnsafeInjectKey, Self> {
         self.request(request::UnsafeInjectKey {
             mechanism,
-            raw_key: ShortData::from_slice(raw_key).unwrap(),
+            raw_key: SerializedKey::from_slice(raw_key).unwrap(),
             attributes: StorageAttributes::new().set_persistence(persistence),
             format,
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,9 +13,6 @@ pub type MAX_OBJECT_HANDLES = consts::U16;
 pub type MAX_LABEL_LENGTH = consts::U256;
 pub const MAX_MEDIUM_DATA_LENGTH: usize = 256;
 pub type MAX_PATH_LENGTH = consts::U256;
-pub const MAX_KEY_MATERIAL_LENGTH: usize = 128;
-// must be above + 4
-pub const MAX_SERIALIZED_KEY_LENGTH: usize = 132;
 cfg_if::cfg_if! {
     if #[cfg(feature = "clients-12")] {
         pub type MAX_SERVICE_CLIENTS = consts::U12;
@@ -44,7 +41,14 @@ cfg_if::cfg_if! {
     }
 }
 pub const MAX_SHORT_DATA_LENGTH: usize = 128;
-pub const MAX_SIGNATURE_LENGTH: usize = 72;
+
+pub const MAX_SIGNATURE_LENGTH: usize = 512 * 2;
+// FIXME: Value from https://stackoverflow.com/questions/5403808/private-key-length-bytes for Rsa2048 Private key
+pub const MAX_KEY_MATERIAL_LENGTH: usize = 1160 * 2 + 72;
+
+// must be MAX_KEY_MATERIAL_LENGTH + 4
+pub const MAX_SERIALIZED_KEY_LENGTH: usize = MAX_KEY_MATERIAL_LENGTH + 4;
+
 pub const MAX_USER_ATTRIBUTE_LENGTH: usize = 256;
 
 pub const USER_ATTRIBUTE_NUMBER: u8 = 37;

--- a/src/key.rs
+++ b/src/key.rs
@@ -63,6 +63,9 @@ pub enum Kind {
     Symmetric(usize),
     /// 32B symmetric key + nonce, the parameter is the length of the nonce in bytes
     Symmetric32Nonce(usize),
+    Rsa2048,
+    Rsa3072,
+    Rsa4096,
     Ed255,
     P256,
     X255,
@@ -150,6 +153,9 @@ impl Kind {
             Kind::Ed255 => 4,
             Kind::P256 => 5,
             Kind::X255 => 6,
+            Kind::Rsa2048 => 7,
+            Kind::Rsa3072 => 8,
+            Kind::Rsa4096 => 9,
         }
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -167,6 +167,9 @@ impl Kind {
             4 => Self::Ed255,
             5 => Self::P256,
             6 => Self::X255,
+            7 => Kind::Rsa2048,
+            8 => Kind::Rsa3072,
+            9 => Kind::Rsa4096,
             _ => return Err(Error::InvalidSerializedKey),
         })
     }

--- a/src/mechanisms/ed255.rs
+++ b/src/mechanisms/ed255.rs
@@ -142,7 +142,7 @@ impl SerializeKey for super::Ed255 {
             }
 
             KeySerialization::Raw => {
-                let mut serialized_key = Message::new();
+                let mut serialized_key = SerializedKey::new();
                 serialized_key
                     .extend_from_slice(public_key.as_bytes())
                     .map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -240,6 +240,7 @@ impl SerializeKey for super::P256 {
                     .map_err(|_| Error::InternalError)?;
                 serialized_key
             }
+            _ => return Err(Error::InvalidSerializationFormat),
         };
 
         Ok(reply::SerializeKey { serialized_key })

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -224,7 +224,7 @@ impl SerializeKey for super::P256 {
                 crate::cbor_serialize_bytes(&cose_pk).map_err(|_| Error::CborError)?
             }
             KeySerialization::Raw => {
-                let mut serialized_key = Message::new();
+                let mut serialized_key = SerializedKey::new();
                 serialized_key
                     .extend_from_slice(&public_key.x())
                     .map_err(|_| Error::InternalError)?;
@@ -234,7 +234,7 @@ impl SerializeKey for super::P256 {
                 serialized_key
             }
             KeySerialization::Sec1 => {
-                let mut serialized_key = Message::new();
+                let mut serialized_key = SerializedKey::new();
                 serialized_key
                     .extend_from_slice(&public_key.to_compressed_sec1_bytes())
                     .map_err(|_| Error::InternalError)?;

--- a/src/mechanisms/shared_secret.rs
+++ b/src/mechanisms/shared_secret.rs
@@ -22,7 +22,7 @@ impl SerializeKey for super::SharedSecret {
         if !key.flags.contains(key::Flags::SERIALIZABLE) {
             return Err(Error::InvalidSerializedKey);
         };
-        let mut serialized_key = Message::new();
+        let mut serialized_key = SerializedKey::new();
         serialized_key.extend_from_slice(&key.material).unwrap();
 
         Ok(reply::SerializeKey { serialized_key })

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -149,7 +149,7 @@ impl SerializeKey for super::X255 {
         let key_id = request.key;
         let public_key = load_public_key(keystore, &key_id)?;
 
-        let mut serialized_key = Message::new();
+        let mut serialized_key = SerializedKey::new();
         match request.format {
             KeySerialization::Raw => {
                 serialized_key

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -2,6 +2,7 @@ use chacha20::ChaCha8Rng;
 use littlefs2::path::PathBuf;
 
 use crate::{
+    config::MAX_KEY_MATERIAL_LENGTH,
     error::{Error, Result},
     key,
     store::{self, Store},
@@ -172,7 +173,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
 
         let location = self.location(secrecy, id).ok_or(Error::NoSuchKey)?;
 
-        let bytes: Bytes<128> = store::read(self.store, location, &path)?;
+        let bytes: Bytes<{ MAX_KEY_MATERIAL_LENGTH }> = store::read(self.store, location, &path)?;
 
         let key = key::Key::try_deserialize(&bytes)?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -578,6 +578,7 @@ pub type MediumData = Bytes<MAX_MEDIUM_DATA_LENGTH>;
 pub type ShortData = Bytes<MAX_SHORT_DATA_LENGTH>;
 
 pub type Message = Bytes<MAX_MESSAGE_LENGTH>;
+pub type SerializedKey = Bytes<MAX_KEY_MATERIAL_LENGTH>;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum KeySerialization {

--- a/src/types.rs
+++ b/src/types.rs
@@ -568,6 +568,9 @@ pub enum Mechanism {
     X255,
     /// Used to serialize the output of a diffie-hellman
     SharedSecret,
+    Rsa2048Pkcs1v15,
+    Rsa3072Pkcs1v15,
+    Rsa4096Pkcs1v15,
 }
 
 pub type LongData = Bytes<MAX_LONG_DATA_LENGTH>;
@@ -584,6 +587,12 @@ pub enum KeySerialization {
     EcdhEsHkdf256,
     Raw,
     Sec1,
+    /// Used by backends implementing RSA.
+    ///
+    /// Since RSA keys have multiple parts, and that the [`SerializeKey`](crate::api::Reply::SerializeKey) and
+    /// [`UnsafeInjectKey`](crate::api::Request::UnsafeInjectKey) have only transfer one byte array, the RSA key is serialized with postcard
+    RsaParts,
+    Pkcs8Der,
 }
 
 pub type Signature = Bytes<MAX_SIGNATURE_LENGTH>;


### PR DESCRIPTION
We will port the RSA implementation to a custom backend. While backends can have extensions, they can't have custom `Mechanisms` and `Serialization` for the normal APIs. This patch adds them so that they can be implemented by the custom backend.