### PR TITLE
Simplify ClientBuilder

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -709,7 +709,9 @@ impl<P: Platform> Service<P> {
         client_id: &str,
         syscall: S,
     ) -> Result<ClientImplementation<S>, Error> {
-        ClientBuilder::new(client_id).build(self, syscall)
+        ClientBuilder::new(client_id)
+            .prepare(self)
+            .map(|p| p.build(syscall))
     }
 
     /// Specialization of `try_new_client`, using `self`'s implementation of `Syscall`
@@ -719,13 +721,20 @@ impl<P: Platform> Service<P> {
         &mut self,
         client_id: &str,
     ) -> Result<ClientImplementation<&mut Self>, Error> {
-        ClientBuilder::new(client_id).build_with_service_mut(self)
+        ClientBuilder::new(client_id)
+            .prepare(self)
+            .map(|p| p.build(self))
     }
 
     /// Similar to [try_as_new_client][Service::try_as_new_client] except that the returning client owns the
     /// Service and is therefore `'static`
-    pub fn try_into_new_client(self, client_id: &str) -> Result<ClientImplementation<Self>, Error> {
-        ClientBuilder::new(client_id).build_with_service(self)
+    pub fn try_into_new_client(
+        mut self,
+        client_id: &str,
+    ) -> Result<ClientImplementation<Self>, Error> {
+        ClientBuilder::new(client_id)
+            .prepare(&mut self)
+            .map(|p| p.build(self))
     }
 }
 

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -97,11 +97,12 @@ impl<S: StoreProvider> Platform<S> {
         backends: &'static [BackendId<D::BackendId>],
         test: impl FnOnce(ClientImplementation<Service<Self, D>, D>) -> R,
     ) -> R {
-        let service = Service::with_dispatch(self, dispatch);
+        let mut service = Service::with_dispatch(self, dispatch);
         let client = ClientBuilder::new(client_id)
             .backends(backends)
-            .build_with_service(service)
-            .unwrap();
+            .prepare(&mut service)
+            .unwrap()
+            .build(service);
         test(client)
     }
 }


### PR DESCRIPTION
Instead of having different methods to build a client from a generic Syscall implementation, a &mut Service or a Service, introduce a two-step process:  firstly allocating the endpoint and the interchange using a &mut Service; secondly creating the client using a Syscall implementation.