### PR TITLE
Add assertions for interchange size

### DIFF
--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -81,3 +81,36 @@ pub struct ServiceEndpoint<I: 'static, C> {
 }
 
 // pub type ClientEndpoint = Requester<TrussedInterchange>;
+
+#[cfg(test)]
+mod tests {
+    use super::TrussedInterchange;
+    use crate::api::{Reply, Request};
+    use core::mem;
+
+    // The following checks are used to ensure that we don’t accidentally increase the interchange
+    // size.  Bumping the size is not a breaking change but should only be done if really
+    // necessary.
+
+    const MAX_SIZE: usize = 2416;
+
+    fn assert_size<T>() {
+        let size = mem::size_of::<T>();
+        assert!(size <= MAX_SIZE, "{size}");
+    }
+
+    #[test]
+    fn test_request_size() {
+        assert_size::<Request>();
+    }
+
+    #[test]
+    fn test_reply_size() {
+        assert_size::<Reply>();
+    }
+
+    #[test]
+    fn test_interchange_size() {
+        assert_size::<TrussedInterchange>();
+    }
+}


### PR DESCRIPTION
This patch adds assertions on the size of the Request, Reply and TrussedInterchange types so that we don’t accidentally increase it.

----

Increasing the interchange size can easily cost us lots of memory if many clients are used.  This patch is intended to help us keep track of the memory requirements.  Thoughts?