### PR TITLE
Drop P parameter from backend and extension traits

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -27,13 +27,13 @@ pub enum BackendId<I> {
 }
 
 /// A custom backend that can override the core request implementations.
-pub trait Backend<P: Platform> {
+pub trait Backend {
     /// The context for requests handled by this backend.
     type Context: Default;
 
     /// Executes a request using this backend or returns [`Error::RequestNotAvailable`][] if it is
     /// not supported by this backend.
-    fn request(
+    fn request<P: Platform>(
         &mut self,
         core_ctx: &mut CoreContext,
         backend_ctx: &mut Self::Context,
@@ -51,7 +51,7 @@ pub trait Backend<P: Platform> {
 /// Otherwise it can provide an implementation of this trait that defines which backends are
 /// supported.  The backends that are used to execute a request can be selected when constructing a
 /// client using [`ClientBuilder::backends`][`crate::client::ClientBuilder::backends`].
-pub trait Dispatch<P: Platform> {
+pub trait Dispatch {
     /// The ID type for the custom backends used by this dispatch implementation.
     type BackendId: 'static;
     /// The context type used by this dispatch.
@@ -59,7 +59,7 @@ pub trait Dispatch<P: Platform> {
 
     /// Executes a request using a backend or returns [`Error::RequestNotAvailable`][] if it is not
     /// supported by the backend.
-    fn request(
+    fn request<P: Platform>(
         &mut self,
         backend: &Self::BackendId,
         ctx: &mut Context<Self::Context>,
@@ -76,7 +76,7 @@ pub trait Dispatch<P: Platform> {
 pub struct CoreOnly;
 
 #[cfg(not(feature = "serde-extensions"))]
-impl<P: Platform> Dispatch<P> for CoreOnly {
+impl Dispatch for CoreOnly {
     type BackendId = NoId;
     type Context = crate::types::NoData;
 }

--- a/src/serde_extensions.rs
+++ b/src/serde_extensions.rs
@@ -37,7 +37,7 @@ pub trait Extension {
 }
 
 /// Dispatches extension requests to custom backends.
-pub trait ExtensionDispatch<P: Platform> {
+pub trait ExtensionDispatch {
     /// The ID type for the custom backends used by this dispatch implementation.
     type BackendId: 'static;
     /// The context type used by this dispatch.
@@ -47,7 +47,7 @@ pub trait ExtensionDispatch<P: Platform> {
 
     /// Executes a request using a backend or returns [`Error::RequestNotAvailable`][] if it is not
     /// supported by the backend.
-    fn core_request(
+    fn core_request<P: Platform>(
         &mut self,
         backend: &Self::BackendId,
         ctx: &mut Context<Self::Context>,
@@ -59,7 +59,7 @@ pub trait ExtensionDispatch<P: Platform> {
     }
     /// Executes an extension request using a backend or returns [`Error::RequestNotAvailable`][]
     /// if it is not supported by the backend.
-    fn extension_request(
+    fn extension_request<P: Platform>(
         &mut self,
         backend: &Self::BackendId,
         extension: &Self::ExtensionId,
@@ -72,11 +72,11 @@ pub trait ExtensionDispatch<P: Platform> {
     }
 }
 
-impl<P: Platform, T: ExtensionDispatch<P>> Dispatch<P> for T {
+impl<T: ExtensionDispatch> Dispatch for T {
     type BackendId = T::BackendId;
     type Context = T::Context;
 
-    fn request(
+    fn request<P: Platform>(
         &mut self,
         backend: &Self::BackendId,
         ctx: &mut Context<Self::Context>,
@@ -95,16 +95,16 @@ impl<P: Platform, T: ExtensionDispatch<P>> Dispatch<P> for T {
     }
 }
 
-impl<P: Platform> ExtensionDispatch<P> for CoreOnly {
+impl ExtensionDispatch for CoreOnly {
     type BackendId = NoId;
     type Context = types::NoData;
     type ExtensionId = NoId;
 }
 
 /// Implements an extension for a backend.
-pub trait ExtensionImpl<E: Extension, P: Platform>: Backend<P> {
+pub trait ExtensionImpl<E: Extension>: Backend {
     /// Handles an extension request.
-    fn extension_request(
+    fn extension_request<P: Platform>(
         &mut self,
         core_ctx: &mut CoreContext,
         backend_ctx: &mut Self::Context,
@@ -115,7 +115,7 @@ pub trait ExtensionImpl<E: Extension, P: Platform>: Backend<P> {
     /// Handles an extension request and performs the necessary serialization and deserialization
     /// between [`request::SerdeExtension`][] and [`Extension::Request`][] as well as
     /// [`reply::SerdeExtension`][] and [`Extension::Reply`][].
-    fn extension_request_serialized(
+    fn extension_request_serialized<P: Platform>(
         &mut self,
         core_ctx: &mut CoreContext,
         backend_ctx: &mut Self::Context,

--- a/src/service.rs
+++ b/src/service.rs
@@ -82,7 +82,7 @@ impl<P: Platform> ServiceResources<P> {
 pub struct Service<P, D = CoreOnly>
 where
     P: Platform,
-    D: Dispatch<P>,
+    D: Dispatch,
 {
     eps: Vec<ServiceEndpoint<D::BackendId, D::Context>, { MAX_SERVICE_CLIENTS::USIZE }>,
     resources: ServiceResources<P>,
@@ -90,7 +90,7 @@ where
 }
 
 // need to be able to send crypto service to an interrupt handler
-unsafe impl<P: Platform, D: Dispatch<P>> Send for Service<P, D> {}
+unsafe impl<P: Platform, D: Dispatch> Send for Service<P, D> {}
 
 impl<P: Platform> ServiceResources<P> {
     pub fn certstore(&mut self, ctx: &CoreContext) -> Result<ClientCertstore<P::S>> {
@@ -119,7 +119,7 @@ impl<P: Platform> ServiceResources<P> {
             .map_err(|_| Error::EntropyMalfunction)
     }
 
-    pub fn dispatch<D: Dispatch<P>>(
+    pub fn dispatch<D: Dispatch>(
         &mut self,
         dispatch: &mut D,
         backend: &BackendId<D::BackendId>,
@@ -690,7 +690,7 @@ impl<P: Platform> Service<P> {
     }
 }
 
-impl<P: Platform, D: Dispatch<P>> Service<P, D> {
+impl<P: Platform, D: Dispatch> Service<P, D> {
     pub fn with_dispatch(platform: P, dispatch: D) -> Self {
         let resources = ServiceResources::new(platform);
         Self {
@@ -738,7 +738,7 @@ impl<P: Platform> Service<P> {
     }
 }
 
-impl<P: Platform, D: Dispatch<P>> Service<P, D> {
+impl<P: Platform, D: Dispatch> Service<P, D> {
     pub fn add_endpoint(
         &mut self,
         interchange: Responder<TrussedInterchange>,
@@ -842,7 +842,7 @@ impl<P: Platform, D: Dispatch<P>> Service<P, D> {
 impl<P, D> crate::client::Syscall for &mut Service<P, D>
 where
     P: Platform,
-    D: Dispatch<P>,
+    D: Dispatch,
 {
     fn syscall(&mut self) {
         self.process();
@@ -852,7 +852,7 @@ where
 impl<P, D> crate::client::Syscall for Service<P, D>
 where
     P: Platform,
-    D: Dispatch<P>,
+    D: Dispatch,
 {
     fn syscall(&mut self) {
         self.process();

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -90,7 +90,7 @@ impl<S: StoreProvider> Platform<S> {
         test(client)
     }
 
-    pub fn run_client_with_backends<R, D: Dispatch<Self>>(
+    pub fn run_client_with_backends<R, D: Dispatch>(
         self,
         client_id: &str,
         dispatch: D,

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -26,16 +26,16 @@ struct Dispatch {
     test: TestBackend,
 }
 
-impl backend::Dispatch<Platform> for Dispatch {
+impl backend::Dispatch for Dispatch {
     type BackendId = Backend;
     type Context = ();
 
-    fn request(
+    fn request<P: platform::Platform>(
         &mut self,
         backend: &Self::BackendId,
         ctx: &mut Context<()>,
         request: &Request,
-        resources: &mut ServiceResources<Platform>,
+        resources: &mut ServiceResources<P>,
     ) -> Result<Reply, Error> {
         match backend {
             Backend::Test => {
@@ -49,10 +49,10 @@ impl backend::Dispatch<Platform> for Dispatch {
 #[derive(Default)]
 struct TestBackend;
 
-impl<P: platform::Platform> backend::Backend<P> for TestBackend {
+impl backend::Backend for TestBackend {
     type Context = ();
 
-    fn request(
+    fn request<P: platform::Platform>(
         &mut self,
         _core_ctx: &mut CoreContext,
         _backend_ctx: &mut Self::Context,

--- a/tests/serde_extensions.rs
+++ b/tests/serde_extensions.rs
@@ -236,12 +236,12 @@ mod backends {
     /// Implements TestExtension
     pub struct TestBackend;
 
-    impl<P: Platform> Backend<P> for TestBackend {
+    impl Backend for TestBackend {
         type Context = TestContext;
     }
 
-    impl<P: Platform> ExtensionImpl<TestExtension, P> for TestBackend {
-        fn extension_request(
+    impl ExtensionImpl<TestExtension> for TestBackend {
+        fn extension_request<P: Platform>(
             &mut self,
             _core_ctx: &mut CoreContext,
             backend_ctx: &mut TestContext,
@@ -273,12 +273,12 @@ mod backends {
     /// Implements SampleExtension and TestExtension
     pub struct SampleBackend;
 
-    impl<P: Platform> Backend<P> for SampleBackend {
+    impl Backend for SampleBackend {
         type Context = SampleContext;
     }
 
-    impl<P: Platform> ExtensionImpl<SampleExtension, P> for SampleBackend {
-        fn extension_request(
+    impl ExtensionImpl<SampleExtension> for SampleBackend {
+        fn extension_request<P: Platform>(
             &mut self,
             _core_ctx: &mut CoreContext,
             backend_ctx: &mut SampleContext,
@@ -301,8 +301,8 @@ mod backends {
         }
     }
 
-    impl<P: Platform> ExtensionImpl<TestExtension, P> for SampleBackend {
-        fn extension_request(
+    impl ExtensionImpl<TestExtension> for SampleBackend {
+        fn extension_request<P: Platform>(
             &mut self,
             _core_ctx: &mut CoreContext,
             backend_ctx: &mut SampleContext,
@@ -386,12 +386,12 @@ mod runner {
         sample: SampleContext,
     }
 
-    impl<P: Platform> ExtensionDispatch<P> for Backends {
+    impl ExtensionDispatch for Backends {
         type BackendId = id::Backend;
         type Context = BackendsContext;
         type ExtensionId = id::Extension;
 
-        fn core_request(
+        fn core_request<P: Platform>(
             &mut self,
             backend: &Self::BackendId,
             ctx: &mut Context<Self::Context>,
@@ -410,7 +410,7 @@ mod runner {
             }
         }
 
-        fn extension_request(
+        fn extension_request<P: Platform>(
             &mut self,
             backend: &Self::BackendId,
             extension: &Self::ExtensionId,
@@ -429,14 +429,14 @@ mod runner {
                     id::Extension::Sample => Err(Error::RequestNotAvailable),
                 },
                 id::Backend::Sample => match extension {
-                    id::Extension::Test => <SampleBackend as ExtensionImpl<TestExtension, P>>::extension_request_serialized(
+                    id::Extension::Test => <SampleBackend as ExtensionImpl<TestExtension>>::extension_request_serialized(
                         &mut self.sample,
                         &mut ctx.core,
                         &mut ctx.backends.sample,
                         request,
                         resources,
                     ),
-                    id::Extension::Sample => <SampleBackend as ExtensionImpl<SampleExtension, P>>::extension_request_serialized(
+                    id::Extension::Sample => <SampleBackend as ExtensionImpl<SampleExtension>>::extension_request_serialized(
                         &mut self.sample,
                         &mut ctx.core,
                         &mut ctx.backends.sample,


### PR DESCRIPTION
The Backend, Dispatch, ExtensionImpl and ExtensionDispatch traits don’t need to have the platform as a type parameter P.  It is sufficient if the request handling methods receive it as a type parameter.  This makes it easier to implement the traits.