### PR TITLE
Add derive macros for Dispatch, ExtensionDispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,26 +34,26 @@ jobs:
           release: "9-2020-q2"
 
       - name: Build
-        run: cargo build --verbose --target ${{ matrix.target }}
+        run: cargo build --workspace --target ${{ matrix.target }}
 
       - name: Check all targets without default features
-        run: cargo check --all-targets --no-default-features
+        run: cargo check --workspace --all-targets --no-default-features
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Check all targets with default features
-        run: cargo check --all-targets
+        run: cargo check --workspace --all-targets
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Check all features and targets
-        run: cargo check --all-features --all-targets
+        run: cargo check --workspace --all-features --all-targets
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Run tests
-        run: cargo test --verbose --features serde-extensions,virt
+        run: cargo test --features serde-extensions,virt
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Check formatting
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Check clippy lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,23 @@
+[workspace]
+members = ["derive"]
+
+[workspace.package]
+authors = ["Nicolas Stalder <n@stalder.io>", "Nitrokey GmbH"]
+edition = "2021"
+homepage = "https://trussed.dev"
+license = "Apache-2.0 OR MIT"
+
 [package]
 name = "trussed"
 version = "0.1.0"
-authors = ["Nicolas Stalder <n@stalder.io>"]
-edition = "2021"
-homepage = "https://trussed.dev"
 repository = "https://github.com/trussed-dev/trussed"
-license = "Apache-2.0 OR MIT"
 description = "Modern Cryptographic Firmware"
 readme = "README.md"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 
 [dependencies]
 # general
@@ -56,6 +66,7 @@ once_cell = "1.13.0"
 serde_test = "1"
 # If this is not enabled, serde_test makes serde_cbor's compilation fail
 serde_cbor = { version = "0.11.2", features = ["std"] }
+trussed-derive = { path = "derive" }
 # Somehow, this is causing a regression.
 # rand_core = { version = "0.5", features = ["getrandom"] }
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 clippy:
-	cargo clippy --all-features --all-targets -- --deny warnings
+	cargo clippy --workspace --all-features --all-targets -- --deny warnings
 
 quick-test:
 	cargo test -- --nocapture

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "trussed-derive"
+version = "0.1.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.51"
+quote = "1.0.23"
+syn = "2.0.53"
+
+[dev-dependencies]
+serde = { version = "1.0", default-features = false }
+trussed = { path = "..", features = ["serde-extensions", "virt"] }

--- a/derive/examples/dispatch.rs
+++ b/derive/examples/dispatch.rs
@@ -1,0 +1,49 @@
+mod backends {
+    use trussed::backend::Backend;
+
+    #[derive(Default)]
+    pub struct ABackend;
+
+    impl Backend for ABackend {
+        type Context = ();
+    }
+}
+
+enum Backend {
+    A,
+}
+
+#[derive(Default, trussed_derive::Dispatch)]
+#[dispatch(backend_id = "Backend")]
+struct Dispatch {
+    a: backends::ABackend,
+}
+
+fn main() {
+    use trussed::{
+        backend::BackendId,
+        client::CryptoClient,
+        try_syscall,
+        virt::{self, Ram},
+        Error,
+    };
+
+    fn run(backends: &'static [BackendId<Backend>], expected: Option<Error>) {
+        virt::with_platform(Ram::default(), |platform| {
+            platform.run_client_with_backends(
+                "test",
+                Dispatch::default(),
+                backends,
+                |mut client| {
+                    assert_eq!(try_syscall!(client.random_bytes(42)).err(), expected);
+                },
+            )
+        });
+    }
+
+    run(&[BackendId::Core], None);
+    run(
+        &[BackendId::Custom(Backend::A)],
+        Some(Error::RequestNotAvailable),
+    );
+}

--- a/derive/examples/extension-dispatch.rs
+++ b/derive/examples/extension-dispatch.rs
@@ -91,27 +91,10 @@ enum Backend {
     B,
 }
 
+#[derive(trussed_derive::ExtensionId)]
 enum Extension {
     Test = 0,
     Sample = 1,
-}
-
-impl From<Extension> for u8 {
-    fn from(extension: Extension) -> u8 {
-        extension as u8
-    }
-}
-
-impl TryFrom<u8> for Extension {
-    type Error = Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::Test),
-            1 => Ok(Self::Sample),
-            _ => Err(Error::InternalError),
-        }
-    }
 }
 
 #[derive(Default, trussed_derive::ExtensionDispatch)]

--- a/derive/examples/extension-dispatch.rs
+++ b/derive/examples/extension-dispatch.rs
@@ -1,0 +1,143 @@
+use trussed::Error;
+
+mod backends {
+    use super::extensions::{TestExtension, TestReply, TestRequest};
+    use trussed::{
+        backend::Backend, platform::Platform, serde_extensions::ExtensionImpl,
+        service::ServiceResources, types::CoreContext, Error,
+    };
+
+    #[derive(Default)]
+    pub struct ABackend;
+
+    impl Backend for ABackend {
+        type Context = ();
+    }
+
+    impl ExtensionImpl<TestExtension> for ABackend {
+        fn extension_request<P: Platform>(
+            &mut self,
+            _core_ctx: &mut CoreContext,
+            _backend_ctx: &mut Self::Context,
+            _request: &TestRequest,
+            _resources: &mut ServiceResources<P>,
+        ) -> Result<TestReply, Error> {
+            Ok(TestReply)
+        }
+    }
+}
+
+mod extensions {
+    use serde::{Deserialize, Serialize};
+    use trussed::{
+        serde_extensions::{Extension, ExtensionClient, ExtensionResult},
+        Error,
+    };
+
+    pub struct TestExtension;
+
+    impl Extension for TestExtension {
+        type Request = TestRequest;
+        type Reply = TestReply;
+    }
+
+    #[derive(Deserialize, Serialize)]
+    pub struct TestRequest;
+
+    #[derive(Deserialize, Serialize)]
+    pub struct TestReply;
+
+    impl TryFrom<TestReply> for () {
+        type Error = Error;
+
+        fn try_from(_reply: TestReply) -> Result<Self, Self::Error> {
+            Ok(())
+        }
+    }
+
+    pub trait TestClient {
+        fn test(&mut self) -> ExtensionResult<'_, TestExtension, (), Self>;
+    }
+
+    impl<C: ExtensionClient<TestExtension>> TestClient for C {
+        fn test(&mut self) -> ExtensionResult<'_, TestExtension, (), Self> {
+            self.extension(TestRequest)
+        }
+    }
+
+    pub struct SampleExtension;
+
+    impl Extension for SampleExtension {
+        type Request = SampleRequest;
+        type Reply = SampleReply;
+    }
+
+    #[derive(Deserialize, Serialize)]
+    pub struct SampleRequest;
+
+    #[derive(Deserialize, Serialize)]
+    pub struct SampleReply;
+}
+
+enum Backend {
+    A,
+}
+
+enum Extension {
+    Test = 0,
+    Sample = 1,
+}
+
+impl From<Extension> for u8 {
+    fn from(extension: Extension) -> u8 {
+        extension as u8
+    }
+}
+
+impl TryFrom<u8> for Extension {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Test),
+            1 => Ok(Self::Sample),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Default, trussed_derive::ExtensionDispatch)]
+#[dispatch(backend_id = "Backend", extension_id = "Extension")]
+#[extensions(
+    Test = "extensions::TestExtension",
+    Sample = "extensions::SampleExtension"
+)]
+struct Dispatch {
+    #[extensions("Test")]
+    a: backends::ABackend,
+}
+
+fn main() {
+    use extensions::TestClient;
+    use trussed::{
+        backend::BackendId,
+        try_syscall,
+        virt::{self, Ram},
+    };
+
+    fn run(backends: &'static [BackendId<Backend>], expected: Option<Error>) {
+        virt::with_platform(Ram::default(), |platform| {
+            platform.run_client_with_backends(
+                "test",
+                Dispatch::default(),
+                backends,
+                |mut client| {
+                    assert_eq!(try_syscall!(client.test()).err(), expected);
+                },
+            )
+        });
+    }
+
+    run(&[BackendId::Core], Some(Error::RequestNotAvailable));
+    run(&[BackendId::Custom(Backend::A)], None);
+}

--- a/derive/examples/extension-dispatch.rs
+++ b/derive/examples/extension-dispatch.rs
@@ -25,6 +25,13 @@ mod backends {
             Ok(TestReply)
         }
     }
+
+    #[derive(Default)]
+    pub struct BBackend;
+
+    impl Backend for BBackend {
+        type Context = ();
+    }
 }
 
 mod extensions {
@@ -81,6 +88,7 @@ mod extensions {
 
 enum Backend {
     A,
+    B,
 }
 
 enum Extension {
@@ -115,6 +123,7 @@ impl TryFrom<u8> for Extension {
 struct Dispatch {
     #[extensions("Test")]
     a: backends::ABackend,
+    b: backends::BBackend,
 }
 
 fn main() {
@@ -139,5 +148,9 @@ fn main() {
     }
 
     run(&[BackendId::Core], Some(Error::RequestNotAvailable));
+    run(
+        &[BackendId::Custom(Backend::B)],
+        Some(Error::RequestNotAvailable),
+    );
     run(&[BackendId::Custom(Backend::A)], None);
 }

--- a/derive/src/dispatch.rs
+++ b/derive/src/dispatch.rs
@@ -1,0 +1,133 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Error, Field, Generics, Ident, Index, LitStr, Path, Result, Type};
+
+use super::util;
+
+pub struct Dispatch {
+    name: Ident,
+    generics: Generics,
+    attrs: DispatchAttrs,
+    backends: Vec<Backend>,
+}
+
+impl Dispatch {
+    pub fn new(input: DeriveInput) -> Result<Self> {
+        let Data::Struct(data_struct) = &input.data else {
+            return Err(Error::new_spanned(
+                input,
+                "Dispatch can only be derived for structs with named fields",
+            ));
+        };
+        let backends = data_struct
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| Backend::new(i, field))
+            .collect::<Result<_>>()?;
+        let attrs = DispatchAttrs::new(&input)?;
+        Ok(Self {
+            name: input.ident,
+            generics: input.generics,
+            attrs,
+            backends,
+        })
+    }
+
+    pub fn generate(&self) -> TokenStream {
+        let name = &self.name;
+        let backend_id = &self.attrs.backend_id;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        let context = self.backends.iter().map(Backend::context);
+        let requests = self.backends.iter().map(Backend::request);
+
+        quote! {
+            impl #impl_generics ::trussed::backend::Dispatch for #name #ty_generics #where_clause {
+                type BackendId = #backend_id;
+                type Context = (#(#context),*,);
+
+                fn request<P: ::trussed::platform::Platform>(
+                    &mut self,
+                    backend: &Self::BackendId,
+                    ctx: &mut ::trussed::types::Context<Self::Context>,
+                    request: &::trussed::api::Request,
+                    resources: &mut ::trussed::service::ServiceResources<P>,
+                ) -> ::core::result::Result<::trussed::api::Reply, ::trussed::error::Error> {
+                    match backend {
+                        #(#requests)*
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct DispatchAttrs {
+    backend_id: Path,
+}
+
+impl DispatchAttrs {
+    fn new(input: &DeriveInput) -> Result<Self> {
+        let mut backend_id = None;
+
+        let attr = util::require_attr(input, &input.attrs, "dispatch")?;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("backend_id") {
+                let s: LitStr = meta.value()?.parse()?;
+                backend_id = Some(s.parse()?);
+                Ok(())
+            } else {
+                Err(meta.error("unsupported dispatch attribute"))
+            }
+        })?;
+
+        if let Some(backend_id) = backend_id {
+            Ok(Self { backend_id })
+        } else {
+            Err(Error::new_spanned(
+                attr,
+                "missing backend_id key in dispatch attribute",
+            ))
+        }
+    }
+}
+
+struct Backend {
+    id: Ident,
+    field: Ident,
+    ty: Type,
+    index: Index,
+}
+
+impl Backend {
+    fn new(i: usize, field: &Field) -> Result<Self> {
+        let ident = field.ident.clone().ok_or_else(|| {
+            Error::new_spanned(
+                field,
+                "Dispatch can only be derived for a struct with named fields",
+            )
+        })?;
+        Ok(Self {
+            id: util::to_camelcase(&ident),
+            field: ident,
+            ty: field.ty.clone(),
+            index: Index::from(i),
+        })
+    }
+
+    fn context(&self) -> TokenStream {
+        let ty = &self.ty;
+        quote! { <#ty as ::trussed::backend::Backend>::Context }
+    }
+
+    fn request(&self) -> TokenStream {
+        let Self {
+            index, id, field, ..
+        } = self;
+        quote! {
+            Self::BackendId::#id => ::trussed::backend::Backend::request(
+                &mut self.#field, &mut ctx.core, &mut ctx.backends.#index, request, resources,
+            ),
+        }
+    }
+}

--- a/derive/src/extension_dispatch.rs
+++ b/derive/src/extension_dispatch.rs
@@ -1,0 +1,253 @@
+use std::collections::HashMap;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    punctuated::Punctuated, Data, DeriveInput, Error, Field, Generics, Ident, Index, LitStr, Path,
+    Result, Token, Type,
+};
+
+use super::util;
+
+pub struct ExtensionDispatch {
+    name: Ident,
+    generics: Generics,
+    dispatch_attrs: DispatchAttrs,
+    extension_attrs: ExtensionAttrs,
+    backends: Vec<Backend>,
+}
+
+impl ExtensionDispatch {
+    pub fn new(input: DeriveInput) -> Result<Self> {
+        let Data::Struct(data_struct) = &input.data else {
+            return Err(Error::new_spanned(
+                input,
+                "ExtensionDispatch can only be derived for structs with named fields",
+            ));
+        };
+        let dispatch_attrs = DispatchAttrs::new(&input)?;
+        let extension_attrs = ExtensionAttrs::new(&input)?;
+        let backends = data_struct
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| Backend::new(i, field, &extension_attrs.extensions))
+            .collect::<Result<_>>()?;
+        Ok(Self {
+            name: input.ident,
+            generics: input.generics,
+            dispatch_attrs,
+            extension_attrs,
+            backends,
+        })
+    }
+
+    pub fn generate(&self) -> TokenStream {
+        let name = &self.name;
+        let backend_id = &self.dispatch_attrs.backend_id;
+        let extension_id = &self.dispatch_attrs.extension_id;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        let context = self.backends.iter().map(Backend::context);
+        let requests = self.backends.iter().map(Backend::request);
+        let extension_requests = self.backends.iter().map(Backend::extension_request);
+        let extension_impls = self
+            .extension_attrs
+            .extensions
+            .iter()
+            .map(|(id, ty)| self.extension_impl(id, ty));
+
+        quote! {
+            impl #impl_generics ::trussed::serde_extensions::ExtensionDispatch for #name #ty_generics #where_clause {
+                type BackendId = #backend_id;
+                type ExtensionId = #extension_id;
+                type Context = (#(#context),*,);
+
+                fn core_request<P: ::trussed::platform::Platform>(
+                    &mut self,
+                    backend: &Self::BackendId,
+                    ctx: &mut ::trussed::types::Context<Self::Context>,
+                    request: &::trussed::api::Request,
+                    resources: &mut ::trussed::service::ServiceResources<P>,
+                ) -> ::core::result::Result<::trussed::api::Reply, ::trussed::error::Error> {
+                    match backend {
+                        #(#requests)*
+                    }
+                }
+
+                fn extension_request<P: ::trussed::platform::Platform>(
+                    &mut self,
+                    backend: &Self::BackendId,
+                    extension: &Self::ExtensionId,
+                    ctx: &mut ::trussed::types::Context<Self::Context>,
+                    request: &::trussed::api::request::SerdeExtension,
+                    resources: &mut ::trussed::service::ServiceResources<P>,
+                ) -> ::core::result::Result<::trussed::api::reply::SerdeExtension, ::trussed::error::Error> {
+                    match backend {
+                        #(#extension_requests)*
+                    }
+                }
+            }
+
+            #(#extension_impls)*
+        }
+    }
+
+    fn extension_impl(&self, id: &Ident, ty: &Path) -> TokenStream {
+        let name = &self.name;
+        let extension_id = &self.dispatch_attrs.extension_id;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        quote! {
+            impl #impl_generics ::trussed::serde_extensions::ExtensionId<#ty> for #name #ty_generics #where_clause {
+                type Id = #extension_id;
+                const ID: Self::Id = Self::Id::#id;
+            }
+        }
+    }
+}
+
+struct DispatchAttrs {
+    backend_id: Path,
+    extension_id: Path,
+}
+
+impl DispatchAttrs {
+    fn new(input: &DeriveInput) -> Result<Self> {
+        let mut backend_id = None;
+        let mut extension_id = None;
+
+        let attr = util::require_attr(input, &input.attrs, "dispatch")?;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("backend_id") {
+                let s: LitStr = meta.value()?.parse()?;
+                backend_id = Some(s.parse()?);
+                Ok(())
+            } else if meta.path.is_ident("extension_id") {
+                let s: LitStr = meta.value()?.parse()?;
+                extension_id = Some(s.parse()?);
+                Ok(())
+            } else {
+                Err(meta.error("unsupported dispatch attribute"))
+            }
+        })?;
+
+        let backend_id = backend_id.ok_or_else(|| {
+            Error::new_spanned(attr, "missing backend_id key in dispatch attribute")
+        })?;
+        let extension_id = extension_id.ok_or_else(|| {
+            Error::new_spanned(attr, "missing extension_id key in dispatch attribute")
+        })?;
+
+        Ok(Self {
+            backend_id,
+            extension_id,
+        })
+    }
+}
+
+struct ExtensionAttrs {
+    extensions: HashMap<Ident, Path>,
+}
+
+impl ExtensionAttrs {
+    fn new(input: &DeriveInput) -> Result<Self> {
+        let mut extensions: HashMap<Ident, Path> = Default::default();
+
+        let attr = util::require_attr(input, &input.attrs, "extensions")?;
+        attr.parse_nested_meta(|meta| {
+            let ident = meta.path.require_ident()?;
+            let s: LitStr = meta.value()?.parse()?;
+            extensions.insert(ident.to_owned(), s.parse()?);
+            Ok(())
+        })?;
+
+        Ok(Self { extensions })
+    }
+}
+
+struct Backend {
+    id: Ident,
+    field: Ident,
+    ty: Type,
+    index: Index,
+    extensions: Vec<Extension>,
+}
+
+impl Backend {
+    fn new(i: usize, field: &Field, extensions: &HashMap<Ident, Path>) -> Result<Self> {
+        let ident = field.ident.clone().ok_or_else(|| {
+            Error::new_spanned(
+                field,
+                "ExtensionDispatch can only be derived for a struct with named fields",
+            )
+        })?;
+        let extensions = util::require_attr(field, &field.attrs, "extensions")?
+            .parse_args_with(Punctuated::<LitStr, Token![,]>::parse_terminated)?
+            .into_iter()
+            .map(|s| Extension::new(&s, extensions))
+            .collect::<Result<_>>()?;
+        Ok(Self {
+            id: util::to_camelcase(&ident),
+            field: ident,
+            ty: field.ty.clone(),
+            index: Index::from(i),
+            extensions,
+        })
+    }
+
+    fn context(&self) -> TokenStream {
+        let ty = &self.ty;
+        quote! { <#ty as ::trussed::backend::Backend>::Context }
+    }
+
+    fn request(&self) -> TokenStream {
+        let Self {
+            index, id, field, ..
+        } = self;
+        quote! {
+            Self::BackendId::#id => ::trussed::backend::Backend::request(
+                &mut self.#field, &mut ctx.core, &mut ctx.backends.#index, request, resources,
+            ),
+        }
+    }
+
+    fn extension_request(&self) -> TokenStream {
+        let Self { id, extensions, .. } = self;
+        let extension_requests = extensions.iter().map(|e| e.extension_request(self));
+        quote! {
+            Self::BackendId::#id => match extension {
+                #(#extension_requests)*
+                _ => Err(::trussed::error::Error::RequestNotAvailable),
+            }
+        }
+    }
+}
+
+struct Extension {
+    id: Ident,
+    ty: Path,
+}
+
+impl Extension {
+    fn new(s: &LitStr, extensions: &HashMap<Ident, Path>) -> Result<Self> {
+        let id = s.parse()?;
+        let ty = extensions
+            .get(&id)
+            .ok_or_else(|| Error::new_spanned(s, "unknown extension ID"))?
+            .clone();
+        Ok(Self { id, ty })
+    }
+
+    fn extension_request(&self, backend: &Backend) -> TokenStream {
+        let Self { id, ty } = self;
+        let Backend {
+            field: backend_field,
+            index: backend_index,
+            ..
+        } = backend;
+        quote! {
+            Self::ExtensionId::#id => ::trussed::serde_extensions::ExtensionImpl::<#ty>::extension_request_serialized(
+                &mut self.#backend_field, &mut ctx.core, &mut ctx.backends.#backend_index, request, resources
+            ),
+        }
+    }
+}

--- a/derive/src/extension_dispatch.rs
+++ b/derive/src/extension_dispatch.rs
@@ -180,11 +180,14 @@ impl Backend {
                 "ExtensionDispatch can only be derived for a struct with named fields",
             )
         })?;
-        let extensions = util::require_attr(field, &field.attrs, "extensions")?
-            .parse_args_with(Punctuated::<LitStr, Token![,]>::parse_terminated)?
-            .into_iter()
-            .map(|s| Extension::new(&s, extensions))
-            .collect::<Result<_>>()?;
+        let extensions = if let Some(attr) = util::get_attr(&field.attrs, "extensions")? {
+            attr.parse_args_with(Punctuated::<LitStr, Token![,]>::parse_terminated)?
+                .into_iter()
+                .map(|s| Extension::new(&s, extensions))
+                .collect::<Result<_>>()?
+        } else {
+            Default::default()
+        };
         Ok(Self {
             id: util::to_camelcase(&ident),
             field: ident,

--- a/derive/src/extension_id.rs
+++ b/derive/src/extension_id.rs
@@ -1,0 +1,99 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Error, Expr, Generics, Ident, Result, Variant};
+
+pub struct ExtensionId {
+    name: Ident,
+    generics: Generics,
+    extensions: Vec<Extension>,
+}
+
+impl ExtensionId {
+    pub fn new(input: DeriveInput) -> Result<Self> {
+        let Data::Enum(data_enum) = &input.data else {
+            return Err(Error::new_spanned(
+                input,
+                "ExtensionId can only be derived for enums",
+            ));
+        };
+        let extensions = data_enum
+            .variants
+            .iter()
+            .map(Extension::new)
+            .collect::<Result<_>>()?;
+        Ok(Self {
+            name: input.ident,
+            generics: input.generics,
+            extensions,
+        })
+    }
+
+    pub fn generate(&self) -> TokenStream {
+        let name = &self.name;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        let from = self.extensions.iter().map(|e| e.from(name));
+        let try_from = self.extensions.iter().map(Extension::try_from);
+
+        quote! {
+            impl From<#name> for u8 {
+                fn from(extension: #name) -> u8 {
+                    match extension {
+                        #(#from)*
+                    }
+                }
+            }
+
+            impl #impl_generics ::core::convert::TryFrom<u8> for #name #ty_generics #where_clause {
+                type Error = ::trussed::Error;
+
+                fn try_from(value: u8) -> ::core::result::Result<Self, Self::Error> {
+                    match value {
+                        #(#try_from)*
+                        _ => Err(::trussed::Error::InternalError),
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct Extension {
+    name: Ident,
+    id: Expr,
+}
+
+impl Extension {
+    fn new(variant: &Variant) -> Result<Self> {
+        let discriminant = variant
+            .discriminant
+            .as_ref()
+            .ok_or_else(|| {
+                Error::new_spanned(
+                    variant,
+                    "variants for ExtensionId must have an explicit discriminant",
+                )
+            })?
+            .1
+            .clone();
+        Ok(Self {
+            name: variant.ident.clone(),
+            id: discriminant,
+        })
+    }
+
+    fn from(&self, enum_name: &Ident) -> TokenStream {
+        let name = &self.name;
+        let id = &self.id;
+        quote! {
+            #enum_name::#name => #id,
+        }
+    }
+
+    fn try_from(&self) -> TokenStream {
+        let name = &self.name;
+        let id = &self.id;
+        quote! {
+            #id => Ok(Self::#name),
+        }
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,29 @@
+#![deny(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+mod dispatch;
+mod extension_dispatch;
+mod util;
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput, Error};
+
+use dispatch::Dispatch;
+use extension_dispatch::ExtensionDispatch;
+
+#[proc_macro_derive(Dispatch, attributes(dispatch))]
+pub fn derive_dispatch(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    Dispatch::new(input)
+        .map(|d| d.generate())
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(ExtensionDispatch, attributes(dispatch, extensions))]
+pub fn derive_extension_dispatch(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    ExtensionDispatch::new(input)
+        .map(|ed| ed.generate())
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod dispatch;
 mod extension_dispatch;
+mod extension_id;
 mod util;
 
 use proc_macro::TokenStream;
@@ -9,6 +10,7 @@ use syn::{parse_macro_input, DeriveInput, Error};
 
 use dispatch::Dispatch;
 use extension_dispatch::ExtensionDispatch;
+use extension_id::ExtensionId;
 
 #[proc_macro_derive(Dispatch, attributes(dispatch))]
 pub fn derive_dispatch(input: TokenStream) -> TokenStream {
@@ -24,6 +26,15 @@ pub fn derive_extension_dispatch(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     ExtensionDispatch::new(input)
         .map(|ed| ed.generate())
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(ExtensionId)]
+pub fn derive_extension_id(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    ExtensionId::new(input)
+        .map(|d| d.generate())
         .unwrap_or_else(Error::into_compile_error)
         .into()
 }

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -1,0 +1,37 @@
+use quote::ToTokens;
+use syn::{Attribute, Error, Ident, Result};
+
+pub fn require_attr<'a>(
+    span: &dyn ToTokens,
+    attrs: &'a [Attribute],
+    name: &str,
+) -> Result<&'a Attribute> {
+    let mut attrs = attrs.iter().filter(|attr| attr.path().is_ident(name));
+    let first = attrs
+        .next()
+        .ok_or_else(|| Error::new_spanned(span, format!("missing #[{}(...)] attribute", name)))?;
+    if let Some(next) = attrs.next() {
+        Err(Error::new_spanned(
+            next,
+            format!("multiple {} attributes are not supported", name),
+        ))
+    } else {
+        Ok(first)
+    }
+}
+
+pub fn to_camelcase(ident: &Ident) -> Ident {
+    let mut s = String::new();
+    let mut capitalize = true;
+    for c in ident.to_string().chars() {
+        if c == '_' {
+            capitalize = true;
+        } else if capitalize {
+            s.push(c.to_ascii_uppercase());
+            capitalize = false;
+        } else {
+            s.push(c);
+        }
+    }
+    Ident::new(&s, ident.span())
+}

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -1,15 +1,9 @@
 use quote::ToTokens;
 use syn::{Attribute, Error, Ident, Result};
 
-pub fn require_attr<'a>(
-    span: &dyn ToTokens,
-    attrs: &'a [Attribute],
-    name: &str,
-) -> Result<&'a Attribute> {
+pub fn get_attr<'a>(attrs: &'a [Attribute], name: &str) -> Result<Option<&'a Attribute>> {
     let mut attrs = attrs.iter().filter(|attr| attr.path().is_ident(name));
-    let first = attrs
-        .next()
-        .ok_or_else(|| Error::new_spanned(span, format!("missing #[{}(...)] attribute", name)))?;
+    let first = attrs.next();
     if let Some(next) = attrs.next() {
         Err(Error::new_spanned(
             next,
@@ -18,6 +12,15 @@ pub fn require_attr<'a>(
     } else {
         Ok(first)
     }
+}
+
+pub fn require_attr<'a>(
+    span: &dyn ToTokens,
+    attrs: &'a [Attribute],
+    name: &str,
+) -> Result<&'a Attribute> {
+    get_attr(attrs, name)?
+        .ok_or_else(|| Error::new_spanned(span, format!("missing #[{}(...)] attribute", name)))
 }
 
 pub fn to_camelcase(ident: &Ident) -> Ident {

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -1,8 +1,12 @@
 use quote::ToTokens;
 use syn::{Attribute, Error, Ident, Result};
 
-pub fn get_attr<'a>(attrs: &'a [Attribute], name: &str) -> Result<Option<&'a Attribute>> {
-    let mut attrs = attrs.iter().filter(|attr| attr.path().is_ident(name));
+pub fn get_attrs<'a>(attrs: &'a [Attribute], name: &'a str) -> impl Iterator<Item = &'a Attribute> {
+    attrs.iter().filter(|attr| attr.path().is_ident(name))
+}
+
+pub fn get_attr<'a>(attrs: &'a [Attribute], name: &'a str) -> Result<Option<&'a Attribute>> {
+    let mut attrs = get_attrs(attrs, name);
     let first = attrs.next();
     if let Some(next) = attrs.next() {
         Err(Error::new_spanned(
@@ -17,7 +21,7 @@ pub fn get_attr<'a>(attrs: &'a [Attribute], name: &str) -> Result<Option<&'a Att
 pub fn require_attr<'a>(
     span: &dyn ToTokens,
     attrs: &'a [Attribute],
-    name: &str,
+    name: &'a str,
 ) -> Result<&'a Attribute> {
     get_attr(attrs, name)?
         .ok_or_else(|| Error::new_spanned(span, format!("missing #[{}(...)] attribute", name)))

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -2,12 +2,12 @@
 
 use trussed::{
     api::{reply::ReadFile, Reply, Request},
-    backend::{self, Backend as _, BackendId},
+    backend::{self, BackendId},
     client::FilesystemClient as _,
     error::Error,
     platform,
     service::{Service, ServiceResources},
-    types::{Context, CoreContext, Location, Message, PathBuf},
+    types::{CoreContext, Location, Message, PathBuf},
     virt::{self, Ram},
     ClientImplementation,
 };
@@ -21,29 +21,10 @@ pub enum Backend {
     Test,
 }
 
-#[derive(Default)]
+#[derive(Default, trussed_derive::Dispatch)]
+#[dispatch(backend_id = "Backend")]
 struct Dispatch {
     test: TestBackend,
-}
-
-impl backend::Dispatch for Dispatch {
-    type BackendId = Backend;
-    type Context = ();
-
-    fn request<P: platform::Platform>(
-        &mut self,
-        backend: &Self::BackendId,
-        ctx: &mut Context<()>,
-        request: &Request,
-        resources: &mut ServiceResources<P>,
-    ) -> Result<Reply, Error> {
-        match backend {
-            Backend::Test => {
-                self.test
-                    .request(&mut ctx.core, &mut ctx.backends, request, resources)
-            }
-        }
-    }
 }
 
 #[derive(Default)]

--- a/tests/serde_extensions.rs
+++ b/tests/serde_extensions.rs
@@ -328,7 +328,7 @@ mod backends {
 
 mod runner {
     use super::{
-        backends::{SampleBackend, SampleContext, TestBackend, TestContext},
+        backends::{SampleBackend, TestBackend},
         extensions::{SampleExtension, TestExtension},
     };
 
@@ -364,98 +364,17 @@ mod runner {
         }
     }
 
-    use trussed::{
-        api::{reply, request, Reply, Request},
-        backend::{Backend as _, BackendId},
-        error::Error,
-        platform::Platform,
-        serde_extensions::{ExtensionDispatch, ExtensionId, ExtensionImpl},
-        service::ServiceResources,
-        types::Context,
-    };
+    use trussed::backend::BackendId;
+    use trussed_derive::ExtensionDispatch;
 
-    #[derive(Default)]
+    #[derive(Default, ExtensionDispatch)]
+    #[dispatch(backend_id = "id::Backend", extension_id = "id::Extension")]
+    #[extensions(Test = "TestExtension", Sample = "SampleExtension")]
     pub struct Backends {
+        #[extensions("Test")]
         test: TestBackend,
+        #[extensions("Test", "Sample")]
         sample: SampleBackend,
-    }
-
-    #[derive(Default)]
-    pub struct BackendsContext {
-        test: TestContext,
-        sample: SampleContext,
-    }
-
-    impl ExtensionDispatch for Backends {
-        type BackendId = id::Backend;
-        type Context = BackendsContext;
-        type ExtensionId = id::Extension;
-
-        fn core_request<P: Platform>(
-            &mut self,
-            backend: &Self::BackendId,
-            ctx: &mut Context<Self::Context>,
-            request: &Request,
-            resources: &mut ServiceResources<P>,
-        ) -> Result<Reply, Error> {
-            match backend {
-                id::Backend::Test => {
-                    self.test
-                        .request(&mut ctx.core, &mut ctx.backends.test, request, resources)
-                }
-                id::Backend::Sample => {
-                    self.sample
-                        .request(&mut ctx.core, &mut ctx.backends.sample, request, resources)
-                }
-            }
-        }
-
-        fn extension_request<P: Platform>(
-            &mut self,
-            backend: &Self::BackendId,
-            extension: &Self::ExtensionId,
-            ctx: &mut Context<Self::Context>,
-            request: &request::SerdeExtension,
-            resources: &mut ServiceResources<P>,
-        ) -> Result<reply::SerdeExtension, Error> {
-            match backend {
-                id::Backend::Test => match extension {
-                    id::Extension::Test => self.test.extension_request_serialized(
-                        &mut ctx.core,
-                        &mut ctx.backends.test,
-                        request,
-                        resources,
-                    ),
-                    id::Extension::Sample => Err(Error::RequestNotAvailable),
-                },
-                id::Backend::Sample => match extension {
-                    id::Extension::Test => <SampleBackend as ExtensionImpl<TestExtension>>::extension_request_serialized(
-                        &mut self.sample,
-                        &mut ctx.core,
-                        &mut ctx.backends.sample,
-                        request,
-                        resources,
-                    ),
-                    id::Extension::Sample => <SampleBackend as ExtensionImpl<SampleExtension>>::extension_request_serialized(
-                        &mut self.sample,
-                        &mut ctx.core,
-                        &mut ctx.backends.sample,
-                        request,
-                        resources,
-                    ),
-                },
-            }
-        }
-    }
-
-    impl ExtensionId<TestExtension> for Backends {
-        type Id = id::Extension;
-        const ID: Self::Id = Self::Id::Test;
-    }
-
-    impl ExtensionId<SampleExtension> for Backends {
-        type Id = id::Extension;
-        const ID: Self::Id = Self::Id::Sample;
     }
 
     pub const BACKENDS_TEST1: &[BackendId<id::Backend>] =

--- a/tests/serde_extensions.rs
+++ b/tests/serde_extensions.rs
@@ -333,34 +333,15 @@ mod runner {
     };
 
     pub mod id {
-        use trussed::error::Error;
-
         pub enum Backend {
             Test,
             Sample,
         }
 
+        #[derive(trussed_derive::ExtensionId)]
         pub enum Extension {
             Test = 37,
             Sample = 42,
-        }
-
-        impl From<Extension> for u8 {
-            fn from(extension: Extension) -> Self {
-                extension as u8
-            }
-        }
-
-        impl TryFrom<u8> for Extension {
-            type Error = Error;
-
-            fn try_from(value: u8) -> Result<Self, Self::Error> {
-                match value {
-                    37 => Ok(Self::Test),
-                    42 => Ok(Self::Sample),
-                    _ => Err(Error::InternalError),
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Please don’t look at the macro implementation yet, it’s quite messy at the moment.  Instead look at the diff for `tests/backend.rs` and `tests/serde_extensions.rs` to see the derive macros in action.  The current syntax is:

```rust
#[derive(Default, trussed::backend::Dispatch)]
#[dispatch(backend_id = "Backend")]
struct Dispatch {
    test: TestBackend,
}

#[derive(Default, ExtensionDispatch)]
#[dispatch(backend_id = "Backend", extension_id = "Extension")]
#[extensions(Test = "TestExtension", Sample = "SampleExtension")]  // maps the extension ID to the type
pub struct Backends {
    #[extensions("Test")]  // declares the extensions supported by this backend
    test: TestBackend,
    #[extensions("Test", "Sample")]
    sample: SampleBackend,
}
```

What do you think?

----

Missing features:
- [ ] providing different sets of extensions for the same backend with the different IDs
- [x] having multiple `extensions` attributes to simplify conditional compilation
- [ ] warn if an extension is declared but not implemented