### PR TITLE
Migrate to interchange 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the client ID with a `ClientContext` struct.
 - Always trigger syscall in `PollClient::request` and remove
   `PollClient::syscall`.
+- Upgrade the `interchange` dependency to version 0.3.0 ([#99][])
+  - As a consequence the type `pipe::TrussedInterchange` becomes a const`pipe::TRUSSED_INTERCHANGE`
 
 ### Fixed
 
@@ -39,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#64]: https://github.com/trussed-dev/trussed/issues/64
 [#65]: https://github.com/trussed-dev/trussed/issues/65
+[#99]: https://github.com/trussed-dev/trussed/issues/99
 
 ## [0.1.0] - 2022-01-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cosey = "0.3"
 delog = "0.1.0"
 cbor-smol = "0.4"
 heapless-bytes = { version = "0.3.0", features = ["cbor"] }
-interchange = "0.2.1"
+interchange = "0.3.0"
 littlefs2 = "0.3.1"
 p256-cortex-m4 = { version = "0.1.0-alpha.5", features = ["prehash", "sec1-signatures"] }
 salty = { version = "0.2.0", features = ["cose"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,30 +14,32 @@ pub type MAX_LABEL_LENGTH = consts::U256;
 pub const MAX_MEDIUM_DATA_LENGTH: usize = 256;
 pub type MAX_PATH_LENGTH = consts::U256;
 cfg_if::cfg_if! {
-    if #[cfg(feature = "clients-12")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U12;
+    if #[cfg(test)] {
+        pub const MAX_SERVICE_CLIENTS: usize = 6;
+    } else if #[cfg(feature = "clients-12")] {
+        pub const MAX_SERVICE_CLIENTS: usize = 12;
     } else if #[cfg(feature = "clients-11")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U11;
+        pub const MAX_SERVICE_CLIENTS: usize = 11;
     } else if #[cfg(feature = "clients-10")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U10;
+        pub const MAX_SERVICE_CLIENTS: usize = 10;
     } else if #[cfg(feature = "clients-9")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U9;
+        pub const MAX_SERVICE_CLIENTS: usize = 9;
     } else if #[cfg(feature = "clients-8")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U8;
+        pub const MAX_SERVICE_CLIENTS: usize = 8;
     } else if #[cfg(feature = "clients-7")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U7;
+        pub const MAX_SERVICE_CLIENTS: usize = 7;
     } else if #[cfg(feature = "clients-6")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U6;
+        pub const MAX_SERVICE_CLIENTS: usize = 6;
     } else if #[cfg(feature = "clients-5")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U5;
+        pub const MAX_SERVICE_CLIENTS: usize = 5;
     } else if #[cfg(feature = "clients-4")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U4;
+        pub const MAX_SERVICE_CLIENTS: usize = 4;
     } else if #[cfg(feature = "clients-3")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U3;
+        pub const MAX_SERVICE_CLIENTS: usize = 3;
     } else if #[cfg(feature = "clients-2")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U2;
+        pub const MAX_SERVICE_CLIENTS: usize = 2;
     } else if #[cfg(feature = "clients-1")] {
-        pub type MAX_SERVICE_CLIENTS = consts::U1;
+        pub const MAX_SERVICE_CLIENTS: usize = 1;
     }
 }
 pub const MAX_SHORT_DATA_LENGTH: usize = 128;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -2,65 +2,23 @@
 // Ignore lint caused by interchange! macro
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use interchange::Responder;
+use interchange::{Interchange, InterchangeRef, Requester, Responder};
 
 use crate::api::{Reply, Request};
 use crate::backend::BackendId;
+use crate::config;
 use crate::error::Error;
 use crate::types::Context;
 
-cfg_if::cfg_if! {
+type TrussedInterchangeInner =
+    Interchange<Request, Result<Reply, Error>, { config::MAX_SERVICE_CLIENTS }>;
+static TRUSSED_INTERCHANGE_INNER: TrussedInterchangeInner = Interchange::new();
 
-    if #[cfg(feature = "clients-12")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 12)
-        }
-    } else if #[cfg(feature = "clients-11")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 11)
-        }
-    } else if #[cfg(feature = "clients-10")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 10)
-        }
-    } else if #[cfg(feature = "clients-9")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 9)
-        }
-    } else if #[cfg(feature = "clients-8")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 8)
-        }
-    } else if #[cfg(feature = "clients-7")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 7)
-        }
-    } else if #[cfg(feature = "clients-6")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 6)
-        }
-    } else if #[cfg(feature = "clients-5")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 5)
-        }
-    } else if #[cfg(feature = "clients-4")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 4)
-        }
-    } else if #[cfg(feature = "clients-3")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 3)
-        }
-    } else if #[cfg(feature = "clients-2")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 2)
-        }
-    } else if #[cfg(feature = "clients-1")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 1)
-        }
-    }
-}
+pub type TrussedInterchange = InterchangeRef<'static, Request, Result<Reply, Error>>;
+pub static TRUSSED_INTERCHANGE: TrussedInterchange = TRUSSED_INTERCHANGE_INNER.as_interchange_ref();
+
+pub type TrussedResponder = Responder<'static, Request, Result<Reply, Error>>;
+pub type TrussedRequester = Requester<'static, Request, Result<Reply, Error>>;
 
 // pub use interchange::TrussedInterchange;
 
@@ -73,7 +31,7 @@ cfg_if::cfg_if! {
 // https://doc.micrium.com/display/osiiidoc/Using+Message+Queues
 
 pub struct ServiceEndpoint<I: 'static, C> {
-    pub interchange: Responder<TrussedInterchange>,
+    pub interchange: TrussedResponder,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
     pub ctx: Context<C>,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,5 @@
 use chacha20::ChaCha8Rng;
-use heapless_bytes::Unsigned;
-use interchange::Responder;
+
 use littlefs2::path::PathBuf;
 pub use rand_core::{RngCore, SeedableRng};
 
@@ -12,7 +11,7 @@ use crate::error::{Error, Result};
 pub use crate::key;
 use crate::mechanisms;
 pub use crate::pipe::ServiceEndpoint;
-use crate::pipe::TrussedInterchange;
+use crate::pipe::TrussedResponder;
 use crate::platform::*;
 pub use crate::store::{
     certstore::{Certstore as _, ClientCertstore},
@@ -84,7 +83,7 @@ where
     P: Platform,
     D: Dispatch,
 {
-    eps: Vec<ServiceEndpoint<D::BackendId, D::Context>, { MAX_SERVICE_CLIENTS::USIZE }>,
+    eps: Vec<ServiceEndpoint<D::BackendId, D::Context>, { MAX_SERVICE_CLIENTS }>,
     resources: ServiceResources<P>,
     dispatch: D,
 }
@@ -741,7 +740,7 @@ impl<P: Platform> Service<P> {
 impl<P: Platform, D: Dispatch> Service<P, D> {
     pub fn add_endpoint(
         &mut self,
-        interchange: Responder<TrussedInterchange>,
+        interchange: TrussedResponder,
         core_ctx: impl Into<CoreContext>,
         backends: &'static [BackendId<D::BackendId>],
     ) -> Result<(), Error> {
@@ -812,7 +811,7 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
                     .platform
                     .user_interface()
                     .set_status(ui::Status::Idle);
-                ep.interchange.respond(&reply_result).ok();
+                ep.interchange.respond(reply_result).ok();
             }
         }
         debug_now!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,6 @@ use chacha20::ChaCha20;
 use crate::types::*;
 use crate::*;
 use entropy::shannon_entropy;
-use interchange::Interchange;
 use littlefs2::const_ram_storage;
 use littlefs2::fs::{Allocation, Filesystem};
 
@@ -178,12 +177,9 @@ macro_rules! setup {
         let platform = $platform::new(rng, store, pc_interface);
         let mut trussed: crate::Service<$platform> = crate::service::Service::new(platform);
 
-        unsafe {
-            crate::pipe::TrussedInterchange::reset_claims();
-        }
-        let (test_trussed_requester, test_trussed_responder) =
-            crate::pipe::TrussedInterchange::claim()
-                .expect("could not setup TEST TrussedInterchange");
+        let (test_trussed_requester, test_trussed_responder) = crate::pipe::TRUSSED_INTERCHANGE
+            .claim()
+            .expect("could not setup TEST TrussedInterchange");
         let test_client_id = "TEST";
 
         assert!(trussed

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -14,10 +14,9 @@ use rand_core::SeedableRng as _;
 use crate::{
     backend::{BackendId, CoreOnly, Dispatch},
     client::ClientBuilder,
-    pipe::TrussedInterchange,
     platform,
     service::Service,
-    ClientImplementation, Interchange as _,
+    ClientImplementation,
 };
 
 pub use store::{Filesystem, Ram, StoreProvider};
@@ -26,7 +25,7 @@ pub use ui::UserInterface;
 pub type Client<S, D = CoreOnly> = ClientImplementation<Service<Platform<S>, D>, D>;
 
 // We need this mutex to make sure that:
-// - TrussedInterchange is not used concurrently
+// - TrussedInterchange is not used concurrently (panics if violated)
 // - the Store is not used concurrently
 static MUTEX: Mutex<()> = Mutex::new(());
 
@@ -37,7 +36,6 @@ where
 {
     let _guard = MUTEX.lock().unwrap_or_else(|err| err.into_inner());
     unsafe {
-        TrussedInterchange::reset_claims();
         store.reset();
     }
     // causing a regression again


### PR DESCRIPTION
This PR migrates to interchange 0.3.0, using const generics.

I'm also looking to see if we can benefit from the improved flexibility to get rid of the `client-N` feature by having the interchange be provided by the runner instead of coming from trussed.