### PR TITLE
Make the interchange be provided by the runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ once_cell = "1.13.0"
 # rand_core = { version = "0.5", features = ["getrandom"] }
 
 [features]
-default = ["default-mechanisms", "clients-5"]
+default = ["default-mechanisms"]
 serde-extensions = []
 std = []
 verbose-tests = ["littlefs2/ll-assertions"]
@@ -102,19 +102,6 @@ sha256 = []
 tdes = ["des"]
 totp = ["sha-1"]
 trng = ["sha-1"]
-
-clients-1 = []
-clients-2 = []
-clients-3 = []
-clients-4 = []
-clients-5 = []
-clients-6 = []
-clients-7 = []
-clients-8 = []
-clients-9 = []
-clients-10 = []
-clients-11 = []
-clients-12 = []
 
 test-attestation-cert-ids = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,6 @@ clients-11 = []
 clients-12 = []
 
 test-attestation-cert-ids = []
-# [patch.crates-io]
-# interchange = { git = "https://github.com/trussed-dev/interchange", branch = "main" }
 
 [package.metadata.docs.rs]
 features = ["serde-extensions", "virt"]

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(feature = "aes256-cbc")]
-impl<S: Syscall, E> Aes256Cbc for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> Aes256Cbc for ClientImplementation<'pipe, S, E> {}
 
 pub trait Aes256Cbc: CryptoClient {
     fn decrypt_aes256cbc<'c>(
@@ -22,7 +22,7 @@ pub trait Aes256Cbc: CryptoClient {
 }
 
 #[cfg(feature = "chacha8-poly1305")]
-impl<S: Syscall, E> Chacha8Poly1305 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> Chacha8Poly1305 for ClientImplementation<'pipe, S, E> {}
 
 pub trait Chacha8Poly1305: CryptoClient {
     fn decrypt_chacha8poly1305<'c>(
@@ -101,7 +101,7 @@ pub trait Chacha8Poly1305: CryptoClient {
 }
 
 #[cfg(feature = "hmac-blake2s")]
-impl<S: Syscall, E> HmacBlake2s for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> HmacBlake2s for ClientImplementation<'pipe, S, E> {}
 
 pub trait HmacBlake2s: CryptoClient {
     fn hmacblake2s_derive_key(
@@ -133,7 +133,7 @@ pub trait HmacBlake2s: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha1")]
-impl<S: Syscall, E> HmacSha1 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> HmacSha1 for ClientImplementation<'pipe, S, E> {}
 
 pub trait HmacSha1: CryptoClient {
     fn hmacsha1_derive_key(
@@ -165,7 +165,7 @@ pub trait HmacSha1: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha256")]
-impl<S: Syscall, E> HmacSha256 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> HmacSha256 for ClientImplementation<'pipe, S, E> {}
 
 pub trait HmacSha256: CryptoClient {
     fn hmacsha256_derive_key(
@@ -197,7 +197,7 @@ pub trait HmacSha256: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha512")]
-impl<S: Syscall, E> HmacSha512 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> HmacSha512 for ClientImplementation<'pipe, S, E> {}
 
 pub trait HmacSha512: CryptoClient {
     fn hmacsha512_derive_key(
@@ -229,7 +229,7 @@ pub trait HmacSha512: CryptoClient {
 }
 
 #[cfg(feature = "ed255")]
-impl<S: Syscall, E> Ed255 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> Ed255 for ClientImplementation<'pipe, S, E> {}
 
 pub trait Ed255: CryptoClient {
     fn generate_ed255_private_key(
@@ -297,7 +297,7 @@ pub trait Ed255: CryptoClient {
 }
 
 #[cfg(feature = "p256")]
-impl<S: Syscall, E> P256 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> P256 for ClientImplementation<'pipe, S, E> {}
 
 pub trait P256: CryptoClient {
     fn generate_p256_private_key(
@@ -386,7 +386,7 @@ pub trait P256: CryptoClient {
 }
 
 #[cfg(feature = "sha256")]
-impl<S: Syscall, E> Sha256 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> Sha256 for ClientImplementation<'pipe, S, E> {}
 
 pub trait Sha256: CryptoClient {
     fn sha256_derive_key(
@@ -411,7 +411,7 @@ pub trait Sha256: CryptoClient {
 }
 
 #[cfg(feature = "tdes")]
-impl<S: Syscall, E> Tdes for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> Tdes for ClientImplementation<'pipe, S, E> {}
 
 pub trait Tdes: CryptoClient {
     fn decrypt_tdes<'c>(
@@ -432,7 +432,7 @@ pub trait Tdes: CryptoClient {
 }
 
 #[cfg(feature = "totp")]
-impl<S: Syscall, E> Totp for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> Totp for ClientImplementation<'pipe, S, E> {}
 
 pub trait Totp: CryptoClient {
     fn sign_totp(&mut self, key: KeyId, timestamp: u64) -> ClientResult<'_, reply::Sign, Self> {
@@ -446,7 +446,7 @@ pub trait Totp: CryptoClient {
 }
 
 #[cfg(feature = "x255")]
-impl<S: Syscall, E> X255 for ClientImplementation<S, E> {}
+impl<'pipe, S: Syscall, E> X255 for ClientImplementation<'pipe, S, E> {}
 
 pub trait X255: CryptoClient {
     fn generate_x255_secret_key(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,12 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
-use littlefs2::consts;
-
 // TODO: this needs to be overridable.
 // Should we use the "config crate that can have a replacement patched in" idea?
 
-pub type MAX_APPLICATION_NAME_LENGTH = consts::U256;
 pub const MAX_LONG_DATA_LENGTH: usize = 1024;
 pub const MAX_MESSAGE_LENGTH: usize = 1024;
-pub type MAX_OBJECT_HANDLES = consts::U16;
-pub type MAX_LABEL_LENGTH = consts::U256;
 pub const MAX_MEDIUM_DATA_LENGTH: usize = 256;
-pub type MAX_PATH_LENGTH = consts::U256;
 cfg_if::cfg_if! {
     if #[cfg(test)] {
         pub const MAX_SERVICE_CLIENTS: usize = 6;

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,35 +7,7 @@
 pub const MAX_LONG_DATA_LENGTH: usize = 1024;
 pub const MAX_MESSAGE_LENGTH: usize = 1024;
 pub const MAX_MEDIUM_DATA_LENGTH: usize = 256;
-cfg_if::cfg_if! {
-    if #[cfg(test)] {
-        pub const MAX_SERVICE_CLIENTS: usize = 6;
-    } else if #[cfg(feature = "clients-12")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 12;
-    } else if #[cfg(feature = "clients-11")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 11;
-    } else if #[cfg(feature = "clients-10")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 10;
-    } else if #[cfg(feature = "clients-9")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 9;
-    } else if #[cfg(feature = "clients-8")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 8;
-    } else if #[cfg(feature = "clients-7")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 7;
-    } else if #[cfg(feature = "clients-6")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 6;
-    } else if #[cfg(feature = "clients-5")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 5;
-    } else if #[cfg(feature = "clients-4")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 4;
-    } else if #[cfg(feature = "clients-3")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 3;
-    } else if #[cfg(feature = "clients-2")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 2;
-    } else if #[cfg(feature = "clients-1")] {
-        pub const MAX_SERVICE_CLIENTS: usize = 1;
-    }
-}
+
 pub const MAX_SHORT_DATA_LENGTH: usize = 128;
 
 pub const MAX_SIGNATURE_LENGTH: usize = 512 * 2;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -37,7 +37,7 @@ pub struct ServiceEndpoint<'pipe, I: 'static, C> {
 
 #[cfg(test)]
 mod tests {
-    use super::TrussedInterchange;
+    use super::{TrussedRequester, TrussedResponder};
     use crate::api::{Reply, Request};
     use core::mem;
 
@@ -64,6 +64,7 @@ mod tests {
 
     #[test]
     fn test_interchange_size() {
-        assert_size::<TrussedInterchange>();
+        use interchange::Channel;
+        assert_size::<Channel<Request, Reply>>();
     }
 }

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -37,7 +37,6 @@ pub struct ServiceEndpoint<'pipe, I: 'static, C> {
 
 #[cfg(test)]
 mod tests {
-    use super::{TrussedRequester, TrussedResponder};
     use crate::api::{Reply, Request};
     use core::mem;
 
@@ -45,7 +44,7 @@ mod tests {
     // size.  Bumping the size is not a breaking change but should only be done if really
     // necessary.
 
-    const MAX_SIZE: usize = 2416;
+    const MAX_SIZE: usize = 2432;
 
     fn assert_size<T>() {
         let size = mem::size_of::<T>();
@@ -65,6 +64,7 @@ mod tests {
     #[test]
     fn test_interchange_size() {
         use interchange::Channel;
+        // The real cost per-client
         assert_size::<Channel<Request, Reply>>();
     }
 }

--- a/src/serde_extensions.rs
+++ b/src/serde_extensions.rs
@@ -166,7 +166,7 @@ pub trait ExtensionClient<E: Extension>: PollClient {
     }
 }
 
-impl<E, S, I> ExtensionClient<E> for ClientImplementation<S, I>
+impl<'pipe, E, S, I> ExtensionClient<E> for ClientImplementation<'pipe, S, I>
 where
     E: Extension,
     S: Syscall,

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -9,6 +9,7 @@ mod ui;
 use std::{path::PathBuf, sync::Mutex};
 
 use chacha20::ChaCha8Rng;
+use interchange::Interchange;
 use rand_core::SeedableRng as _;
 
 use crate::{
@@ -22,10 +23,10 @@ use crate::{
 pub use store::{Filesystem, Ram, StoreProvider};
 pub use ui::UserInterface;
 
-pub type Client<S, D = CoreOnly> = ClientImplementation<Service<Platform<S>, D>, D>;
+pub type Client<'pipe, S, const MAX_CLIENTS: usize = 1, D = CoreOnly> =
+    ClientImplementation<'pipe, Service<'pipe, Platform<S>, MAX_CLIENTS, D>, D>;
 
 // We need this mutex to make sure that:
-// - TrussedInterchange is not used concurrently (panics if violated)
 // - the Store is not used concurrently
 static MUTEX: Mutex<()> = Mutex::new(());
 
@@ -51,7 +52,7 @@ where
 pub fn with_client<S, R, F>(store: S, client_id: &str, f: F) -> R
 where
     S: StoreProvider,
-    F: FnOnce(Client<S>) -> R,
+    F: for<'pipe> FnOnce(Client<'pipe, S>) -> R,
 {
     with_platform(store, |platform| platform.run_client(client_id, f))
 }
@@ -59,14 +60,14 @@ where
 pub fn with_fs_client<P, R, F>(internal: P, client_id: &str, f: F) -> R
 where
     P: Into<PathBuf>,
-    F: FnOnce(Client<Filesystem>) -> R,
+    F: for<'pipe> FnOnce(Client<'pipe, Filesystem>) -> R,
 {
     with_client(Filesystem::new(internal), client_id, f)
 }
 
 pub fn with_ram_client<R, F>(client_id: &str, f: F) -> R
 where
-    F: FnOnce(Client<Ram>) -> R,
+    F: for<'pipe> FnOnce(Client<'pipe, Ram>) -> R,
 {
     with_client(Ram::default(), client_id, f)
 }
@@ -78,24 +79,28 @@ pub struct Platform<S: StoreProvider> {
 }
 
 impl<S: StoreProvider> Platform<S> {
-    pub fn run_client<R>(
-        self,
-        client_id: &str,
-        test: impl FnOnce(ClientImplementation<Service<Self>>) -> R,
-    ) -> R {
-        let service = Service::new(self);
+    pub fn run_client<R, F>(self, client_id: &str, test: F) -> R
+    where
+        F: for<'pipe> FnOnce(ClientImplementation<'pipe, Service<'pipe, Self, 1>>) -> R,
+    {
+        let interchange = Interchange::new();
+        let service = Service::new(self, &interchange);
         let client = service.try_into_new_client(client_id).unwrap();
         test(client)
     }
 
-    pub fn run_client_with_backends<R, D: Dispatch>(
+    pub fn run_client_with_backends<R, D: Dispatch, F>(
         self,
         client_id: &str,
         dispatch: D,
         backends: &'static [BackendId<D::BackendId>],
-        test: impl FnOnce(ClientImplementation<Service<Self, D>, D>) -> R,
-    ) -> R {
-        let mut service = Service::with_dispatch(self, dispatch);
+        test: F,
+    ) -> R
+    where
+        F: for<'pipe> FnOnce(ClientImplementation<'pipe, Service<'pipe, Self, 1, D>, D>) -> R,
+    {
+        let interchange = Interchange::new();
+        let mut service = Service::with_dispatch(self, &interchange, dispatch);
         let client = ClientBuilder::new(client_id)
             .backends(backends)
             .prepare(&mut service)

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -13,7 +13,7 @@ use trussed::{
 };
 
 type Platform = virt::Platform<Ram>;
-type Client = ClientImplementation<Service<Platform, Dispatch>, Dispatch>;
+type Client<'pipe> = ClientImplementation<'pipe, Service<'pipe, Platform, 1, Dispatch>, Dispatch>;
 
 const BACKENDS_TEST: &[BackendId<Backend>] = &[BackendId::Custom(Backend::Test), BackendId::Core];
 

--- a/tests/serde_extensions.rs
+++ b/tests/serde_extensions.rs
@@ -37,7 +37,7 @@ use trussed::{
 use runner::Backends;
 
 type Platform = virt::Platform<Ram>;
-type Client = ClientImplementation<Service<Platform, Backends>, Backends>;
+type Client<'pipe> = ClientImplementation<'pipe, Service<'pipe, Platform, 1, Backends>, Backends>;
 
 mod extensions {
     use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This allows for more flexibility. Ultimately the goal it to enable running multiple trussed instances at the same time.