### PR TITLE
Add support for ChaCha encryption with keys that don't have a built-in nonce.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -223,7 +223,7 @@ where
         // in particular, can unwrap
         let request = req.into();
         self.pending = Some(u8::from(&request));
-        self.interchange.request(request).map_err(drop).unwrap();
+        self.interchange.request(request).unwrap();
         self.syscall.syscall();
         Ok(FutureResult::new(self))
     }

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -1,12 +1,20 @@
 use crate::api::*;
 // use crate::config::*;
 use crate::error::Error;
+use crate::key;
 use crate::service::*;
 use crate::types::*;
 
 // TODO: The non-detached versions seem better.
 // This needs a bit of additional type gymnastics.
 // Maybe start a discussion on the `aead` crate's GitHub about usability concerns...
+
+const NONCE_LEN: usize = 12;
+const KEY_LEN: usize = 32;
+const TOTAL_LEN: usize = KEY_LEN + NONCE_LEN;
+const TAG_LEN: usize = 16;
+const KIND: key::Kind = key::Kind::Symmetric(KEY_LEN);
+const KIND_NONCE: key::Kind = key::Kind::Symmetric32Nonce(NONCE_LEN);
 
 #[cfg(feature = "chacha8-poly1305")]
 impl GenerateKey for super::Chacha8Poly1305 {
@@ -19,16 +27,16 @@ impl GenerateKey for super::Chacha8Poly1305 {
 
         // 32 bytes entropy
         // 12 bytes nonce
-        let mut serialized = [0u8; 44];
+        let mut serialized = [0u8; TOTAL_LEN];
 
-        let entropy = &mut serialized[..32];
+        let entropy = &mut serialized[..KEY_LEN];
         keystore.rng().fill_bytes(entropy);
 
         // store keys
         let key_id = keystore.store_key(
             request.attributes.persistence,
             key::Secrecy::Secret,
-            key::Kind::Symmetric32Nonce(12),
+            KIND_NONCE,
             &serialized,
         )?;
 
@@ -38,6 +46,7 @@ impl GenerateKey for super::Chacha8Poly1305 {
 
 #[inline(never)]
 fn increment_nonce(nonce: &mut [u8]) -> Result<(), Error> {
+    assert_eq!(nonce.len(), NONCE_LEN);
     let mut carry: u16 = 1;
     for digit in nonce.iter_mut() {
         let x = (*digit as u16) + carry;
@@ -62,20 +71,13 @@ impl Decrypt for super::Chacha8Poly1305 {
         use chacha20poly1305::ChaCha8Poly1305;
 
         let serialized_material = keystore
-            .load_key(
-                key::Secrecy::Secret,
-                Some(key::Kind::Symmetric32Nonce(12)),
-                &request.key,
-            )?
+            .load_key(key::Secrecy::Secret, Some(KIND_NONCE), &request.key)?
             .material;
         let serialized = serialized_material.as_slice();
 
-        // if serialized.len() != 44 {
-        //     return Error::InternalError;
-        // }
-        assert!(serialized.len() == 44);
+        assert!(serialized.len() == TOTAL_LEN);
 
-        let symmetric_key = &serialized[..32];
+        let symmetric_key = &serialized[..KEY_LEN];
 
         let aead = ChaCha8Poly1305::new(&GenericArray::clone_from_slice(symmetric_key));
 
@@ -112,31 +114,25 @@ impl Encrypt for super::Chacha8Poly1305 {
 
         // load key and nonce
         let secrecy = key::Secrecy::Secret;
-        let key_kind = key::Kind::Symmetric32Nonce(12);
         let key_id = &request.key;
-        let mut serialized_material = keystore.load_key(secrecy, Some(key_kind), key_id)?.material;
+        let mut serialized_material = keystore
+            .load_key(secrecy, Some(KIND_NONCE), key_id)?
+            .material;
+
         let serialized: &mut [u8] = serialized_material.as_mut();
 
-        assert!(serialized.len() == 44);
+        assert!(serialized.len() == TOTAL_LEN);
 
         // no panic by above early return
         let location = keystore.location(secrecy, key_id).unwrap();
-
-        // let key_id = request.key;
-        // let path = keystore.prepare_path_for_key(key::Secrecy::Secret, &key_id)?;
-        // let mut serialized = [0u8; 44];
-        // debug!("loading encryption key: {:?}", &path);
-
         {
-            let nonce = &mut serialized[32..];
-            // increment nonce
+            let nonce = &mut serialized[KEY_LEN..];
             increment_nonce(nonce)?;
         }
-        // increment_nonce(&mut serialized[32..])?;
 
-        keystore.overwrite_key(location, secrecy, key_kind, key_id, serialized)?;
+        keystore.overwrite_key(location, secrecy, KIND_NONCE, key_id, serialized)?;
 
-        let (symmetric_key, generated_nonce) = serialized.split_at_mut(32);
+        let (symmetric_key, generated_nonce) = serialized.split_at_mut(KEY_LEN);
 
         let nonce = match request.nonce.as_ref() {
             Some(nonce) => nonce.as_ref(),
@@ -249,158 +245,6 @@ impl UnwrapKey for super::Chacha8Poly1305 {
         Ok(reply::UnwrapKey { key: Some(key_id) })
     }
 }
-
-// // // global choice of algorithm: we do Chacha8Poly1305 here
-// // // TODO: oh how annoying these GenericArrays
-// // pub fn aead_in_place(&mut self, ad: &[u8], buf: &mut [u8]) -> Result<(AeadNonce, AeadTag), Error> {
-// //     use chacha20poly1305::aead::{Aead, NewAead};
-
-// //     // keep in state?
-// //     let aead = ChaCha8Poly1305::new(GenericArray::clone_from_slice(&self.get_aead_key()?));
-// //     // auto-increments
-// //     let nonce = self.get_aead_nonce()?;
-
-// //     // aead.encrypt_in_place_detached(&nonce, ad, buf).map(|g| g.as_slice().try_into().unwrap())?;
-// //     // not sure what can go wrong with AEAD
-// //     let tag: AeadTag = aead.encrypt_in_place_detached(
-// //         &GenericArray::clone_from_slice(&nonce), ad, buf
-// //     ).unwrap().as_slice().try_into().unwrap();
-// //     Ok((nonce, tag))
-// // }
-
-// // pub fn adad_in_place(&mut self, nonce: &AeadNonce, ad: &[u8], buf: &mut [u8], tag: &AeadTag) -> Result<(), Error> {
-// //     use chacha20poly1305::aead::{Aead, NewAead};
-
-// //     // keep in state?
-// //     let aead = ChaCha8Poly1305::new(GenericArray::clone_from_slice(&self.get_aead_key()?));
-
-// //     aead.decrypt_in_place_detached(
-// //         &GenericArray::clone_from_slice(nonce),
-// //         ad,
-// //         buf,
-// //         &GenericArray::clone_from_slice(tag)
-// //     ).map_err(|_| Error::AeadError)
-// // }
-
-// #[cfg(feature = "chacha8-poly1305")]
-// impl<P: Platform>
-// Decrypt<P> for super::Chacha8Poly1305
-// {
-//     fn decrypt(keystore: &mut impl Keystore, request: request::Decrypt)
-//         -> Result<reply::Decrypt, Error>
-//     {
-// 		use block_modes::{BlockMode, Cbc};
-// 		// use block_modes::Cbc;
-// 		use block_modes::block_padding::ZeroPadding;
-// 		use aes::Aes256;
-
-//         // TODO: perhaps use NoPadding and have client pad, to emphasize spec-conformance?
-//         type Aes256Cbc = Cbc<Aes256, ZeroPadding>;
-
-//         let key_id = request.key;
-//         let mut symmetric_key = [0u8; 32];
-//         let path = keystore.prepare_path_for_key(key::Secrecy::Secret, &key_id)?;
-//         keystore.load_serialized_key(&path, key::Kind::SymmetricKey32, &mut symmetric_key)?;
-
-//         let zero_iv = [0u8; 32];
-// 		let cipher = Aes256Cbc::new_var(&symmetric_key, &zero_iv).unwrap();
-
-// 		// buffer must have enough space for message+padding
-// 		let mut buffer = request.message.clone();
-// 		// // copy message to the buffer
-// 		// let pos = plaintext.len();
-// 		// buffer[..pos].copy_from_slice(plaintext);
-//         let l = buffer.len();
-
-//         // Decrypt message in-place.
-//         // Returns an error if buffer length is not multiple of block size and
-//         // if after decoding message has malformed padding.
-// 		let plaintext = cipher.decrypt(&mut buffer).unwrap();
-//         let plaintext = Message::from_slice(&plaintext).unwrap();
-
-//         Ok(reply::Decrypt { plaintext: Ok(plaintext) })
-//     }
-// }
-
-// // TODO: key a `/root/aead-nonce` counter (or use entropy?)
-// // TODO: how do we want to organize this? probably the key itself should have an associated nonce,
-// //       so using a key actually modifies its state!
-// pub fn get_aead_nonce() -> Result<AeadNonce, Error> {
-//     Ok([42u8; 12])
-// }
-
-// impl<P: Platform>
-// Encrypt<P> for super::Chacha8Poly1305
-// {
-//     fn encrypt(keystore: &mut impl Keystore, request: request::Encrypt)
-//         -> Result<reply::Encrypt, Error>
-//     {
-//         use chacha20poly1305::ChaCha8Poly1305;
-
-//         let key_id = request.key;
-//         let path = keystore.prepare_path_for_key(key::Secrecy::Secret, &key_id)?;
-
-//         let mut symmetric_key = [0u8; 32];
-//         keystore.load_serialized_key(&path, key::Kind::SymmetricKey32, &mut symmetric_key)?;
-
-//         // keep in state?
-//         let aead = ChaCha8Poly1305::new(GenericArray::clone_from_slice(&symmetric_key)?);
-//         // auto-increments
-//         let nonce: [u8; 12] = get_aead_nonce()?;
-
-//         let tag: AeadTag = aead.encrypt_in_place_detached(
-//             &GenericArray::clone_from_slice(&nonce), ad, buf
-//         ).unwrap().as_slice().try_into().unwrap();
-//         Ok((nonce, tag))
-
-// 		// // buffer must have enough space for message+padding
-// 		// let mut buffer = request.message.clone();
-// 		// // // copy message to the buffer
-// 		// // let pos = plaintext.len();
-// 		// // buffer[..pos].copy_from_slice(plaintext);
-//         // let l = buffer.len();
-
-//         // // Encrypt message in-place.
-//         // // &buffer[..pos] is used as a message and &buffer[pos..] as a reserved space for padding.
-//         // // The padding space should be big enough for padding, otherwise method will return Err(BlockModeError).
-// 		// let ciphertext = cipher.encrypt(&mut buffer, l).unwrap();
-
-//         // let ciphertext = Message::from_slice(&ciphertext).unwrap();
-//         Ok(reply::Encrypt { ciphertext })
-//     }
-// }
-
-// // // global choice of algorithm: we do Chacha8Poly1305 here
-// // // TODO: oh how annoying these GenericArrays
-// // pub fn aead_in_place(&mut self, ad: &[u8], buf: &mut [u8]) -> Result<(AeadNonce, AeadTag), Error> {
-// //     use chacha20poly1305::aead::{Aead, NewAead};
-
-// //     // keep in state?
-// //     let aead = ChaCha8Poly1305::new(GenericArray::clone_from_slice(&self.get_aead_key()?));
-// //     // auto-increments
-// //     let nonce = self.get_aead_nonce()?;
-
-// //     // aead.encrypt_in_place_detached(&nonce, ad, buf).map(|g| g.as_slice().try_into().unwrap())?;
-// //     // not sure what can go wrong with AEAD
-// //     let tag: AeadTag = aead.encrypt_in_place_detached(
-// //         &GenericArray::clone_from_slice(&nonce), ad, buf
-// //     ).unwrap().as_slice().try_into().unwrap();
-// //     Ok((nonce, tag))
-// // }
-
-// // pub fn adad_in_place(&mut self, nonce: &AeadNonce, ad: &[u8], buf: &mut [u8], tag: &AeadTag) -> Result<(), Error> {
-// //     use chacha20poly1305::aead::{Aead, NewAead};
-
-// //     // keep in state?
-// //     let aead = ChaCha8Poly1305::new(GenericArray::clone_from_slice(&self.get_aead_key()?));
-
-// //     aead.decrypt_in_place_detached(
-// //         &GenericArray::clone_from_slice(nonce),
-// //         ad,
-// //         buf,
-// //         &GenericArray::clone_from_slice(tag)
-// //     ).map_err(|_| Error::AeadError)
-// // }
 
 #[cfg(not(feature = "chacha8-poly1305"))]
 impl<P: Platform> Decrypt<P> for super::Chacha8Poly1305 {}


### PR DESCRIPTION
If the key kind is Symmetric without an nonce and there is no nonce in the request, then a random nonce is generated