### PR TITLE
Allow iterating over the external and volatile filesystems

### DIFF
--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -4,7 +4,7 @@ use trussed::{
     client::{CryptoClient, FilesystemClient},
     error::Error,
     syscall, try_syscall,
-    types::{Location, Mechanism, PathBuf, StorageAttributes},
+    types::{Bytes, Location, Mechanism, PathBuf, StorageAttributes},
 };
 
 mod client;
@@ -52,4 +52,48 @@ fn escape_namespace_root() {
         path.push(&PathBuf::from(key.hex().as_slice()));
         assert!(try_syscall!(client.read_file(Location::Volatile, path)).is_err());
     })
+}
+
+fn iterating(location: Location) {
+    client::get(|client| {
+        syscall!(client.write_file(
+            location,
+            PathBuf::from("foo"),
+            Bytes::from_slice(b"foo").unwrap(),
+            None
+        ));
+        syscall!(client.write_file(
+            location,
+            PathBuf::from("bar"),
+            Bytes::from_slice(b"bar").unwrap(),
+            None
+        ));
+        let first_entry = syscall!(client.read_dir_first(location, PathBuf::from(""), None))
+            .entry
+            .unwrap();
+        assert_eq!(first_entry.file_name(), "bar");
+
+        let next_entry = syscall!(client.read_dir_next()).entry.unwrap();
+        assert_eq!(next_entry.file_name(), "foo");
+
+        let first_data = syscall!(client.read_dir_files_first(location, PathBuf::from(""), None))
+            .data
+            .unwrap();
+        assert_eq!(first_data, b"bar");
+        let next_data = syscall!(client.read_dir_files_next()).data.unwrap();
+        assert_eq!(next_data, b"foo");
+    });
+}
+
+#[test]
+fn iterating_internal() {
+    iterating(Location::Internal);
+}
+#[test]
+fn iterating_external() {
+    iterating(Location::External);
+}
+#[test]
+fn iterating_volatile() {
+    iterating(Location::Volatile);
 }


### PR DESCRIPTION
This PR fixes a previous limitation where the methods for iterating over the filesystem only allowed iterating over the internal filesystem.