### PR TITLE
wrap_key: Don't ignore associated data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client ([#64]).
 - Fixed missing path validation in `Filestore` that allowed clients to escape
   their namespace ([#65]).
+- wrap_key: Don't replace associated data with an empty array
 
 [#64]: https://github.com/trussed-dev/trussed/issues/64
 [#65]: https://github.com/trussed-dev/trussed/issues/65

--- a/src/api.rs
+++ b/src/api.rs
@@ -311,7 +311,7 @@ pub mod request {
           - mechanism: Mechanism
           - wrapping_key: KeyId
           - key: KeyId
-          - associated_data: Message
+          - associated_data: ShortData
 
         RequestUserConsent:
           - level: consent::Level

--- a/src/client.rs
+++ b/src/client.rs
@@ -523,7 +523,7 @@ pub trait CryptoClient: PollClient {
         associated_data: &[u8],
     ) -> ClientResult<'_, reply::WrapKey, Self> {
         let associated_data =
-            Message::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
+            Bytes::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
         self.request(request::WrapKey {
             mechanism,
             wrapping_key,

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -82,7 +82,7 @@ impl WrapKey for super::Aes256Cbc {
             mechanism: Mechanism::Aes256Cbc,
             key: request.wrapping_key,
             message,
-            associated_data: ShortData::new(),
+            associated_data: request.associated_data.clone(),
             nonce: None,
         };
         let encryption_reply = <super::Aes256Cbc>::encrypt(keystore, &encryption_request)?;

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -188,7 +188,7 @@ impl WrapKey for super::Chacha8Poly1305 {
             mechanism: Mechanism::Chacha8Poly1305,
             key: request.wrapping_key,
             message,
-            associated_data: ShortData::new(),
+            associated_data: request.associated_data.clone(),
             nonce: None,
         };
         let encryption_reply = <super::Chacha8Poly1305>::encrypt(keystore, &encryption_request)?;


### PR DESCRIPTION
Associated data was ignored in call to `wrap_key`. This fixes it. Thankfully it wasn't ignored in `unwrap_key` so we're fine.