### PR TITLE
Put debug-dump-store behind a feature-flag

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -312,6 +312,9 @@ impl<P: Platform> ServiceResources<P> {
                 info_now!(":: PERSISTENT");
                 recursively_list(self.platform.store().ifs(), path!("/"));
 
+                info_now!(":: EXTERNAL");
+                recursively_list(self.platform.store().efs(), PathBuf::from("/"));
+
                 info_now!(":: VOLATILE");
                 recursively_list(self.platform.store().vfs(), path!("/"));
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -307,6 +307,7 @@ impl<P: Platform> ServiceResources<P> {
 
             // This is now preferably done using littlefs-fuse (when device is not yet locked),
             // and should be removed from firmware completely
+            #[cfg(debug_dump_store)]
             Request::DebugDumpStore(_request) => {
 
                 info_now!(":: PERSISTENT");
@@ -344,6 +345,9 @@ impl<P: Platform> ServiceResources<P> {
                 Ok(Reply::DebugDumpStore(reply::DebugDumpStore {}) )
 
             }
+
+            #[cfg(not(debug_dump_store))]
+            Request::DebugDumpStore(_request) => Err(Error::RequestNotAvailable),
 
             Request::ReadDirFirst(request) => {
                 let maybe_entry = match filestore.read_dir_first(&request.dir, request.location, request.not_before_filename.as_deref())? {


### PR DESCRIPTION
When debugging https://github.com/Nitrokey/piv-authenticator/pull/12 I realized this was not removed from production firmware. Putting it behind a feature flag will ensure that it does.