### PR TITLE
Add wrap_key_to_file syscall

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -52,10 +52,10 @@ generate_enums! {
     UnsafeInjectKey: 20
     UnsafeInjectSharedKey: 21
     UnwrapKey: 22
-    UnwrapFromFile: 70
+    UnwrapKeyFromFile: 70
     Verify: 23
     WrapKey: 24
-    WrapToFile: 71
+    WrapKeyToFile: 71
 
     Attest: 0xFF
 
@@ -316,7 +316,7 @@ pub mod request {
           - associated_data: ShortData
 
         // this should always be an AEAD algorithm
-        WrapToFile:
+        WrapKeyToFile:
           - mechanism: Mechanism
           - wrapping_key: KeyId
           - key: KeyId
@@ -324,7 +324,7 @@ pub mod request {
           - location: Location
           - associated_data: Message
 
-        UnwrapFromFile:
+        UnwrapKeyFromFile:
           - mechanism: Mechanism
           - key: KeyId
           - path: PathBuf
@@ -486,14 +486,14 @@ pub mod reply {
         UnwrapKey:
             - key: Option<KeyId>
 
-        UnwrapFromFile:
+        UnwrapKeyFromFile:
           - key: Option<KeyId>
 
         WrapKey:
             - wrapped_key: Message
 
         // this should always be an AEAD algorithm
-        WrapToFile:
+        WrapKeyToFile:
 
         // UI
         RequestUserConsent:

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,8 +52,10 @@ generate_enums! {
     UnsafeInjectKey: 20
     UnsafeInjectSharedKey: 21
     UnwrapKey: 22
+    UnwrapFromFile: 70
     Verify: 23
     WrapKey: 24
+    WrapToFile: 71
 
     Attest: 0xFF
 
@@ -313,6 +315,23 @@ pub mod request {
           - key: KeyId
           - associated_data: ShortData
 
+        // this should always be an AEAD algorithm
+        WrapToFile:
+          - mechanism: Mechanism
+          - wrapping_key: KeyId
+          - key: KeyId
+          - path: PathBuf
+          - location: Location
+          - associated_data: Message
+
+        UnwrapFromFile:
+          - mechanism: Mechanism
+          - key: KeyId
+          - path: PathBuf
+          - file_location: Location
+          - key_location: Location
+          - associated_data: Message
+
         RequestUserConsent:
           - level: consent::Level
           - timeout_milliseconds: u32
@@ -467,8 +486,14 @@ pub mod reply {
         UnwrapKey:
             - key: Option<KeyId>
 
+        UnwrapFromFile:
+          - key: Option<KeyId>
+
         WrapKey:
             - wrapped_key: Message
+
+        // this should always be an AEAD algorithm
+        WrapToFile:
 
         // UI
         RequestUserConsent:

--- a/src/client.rs
+++ b/src/client.rs
@@ -535,7 +535,7 @@ pub trait CryptoClient: PollClient {
     /// Wrap a key to a file
     /// This enables wrapping keys that don't fit in the buffers used by
     /// [`write_file`](FilesystemClient::write_file) and [`read_file`](FilesystemClient::read_file)
-    fn wrap_to_file(
+    fn wrap_key_to_file(
         &mut self,
         mechanism: Mechanism,
         wrapping_key: KeyId,
@@ -543,10 +543,10 @@ pub trait CryptoClient: PollClient {
         path: PathBuf,
         location: Location,
         associated_data: &[u8],
-    ) -> ClientResult<'_, reply::WrapToFile, Self> {
+    ) -> ClientResult<'_, reply::WrapKeyToFile, Self> {
         let associated_data =
             Bytes::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
-        self.request(request::WrapToFile {
+        self.request(request::WrapKeyToFile {
             mechanism,
             wrapping_key,
             key,
@@ -559,7 +559,7 @@ pub trait CryptoClient: PollClient {
     /// Wrap a key to a file
     /// This enables wrapping keys that don't fit in the buffers used by
     /// [`write_file`](FilesystemClient::write_file) and [`read_file`](FilesystemClient::read_file)
-    fn unwrap_from_file(
+    fn unwrap_key_from_file(
         &mut self,
         mechanism: Mechanism,
         key: KeyId,
@@ -567,10 +567,10 @@ pub trait CryptoClient: PollClient {
         file_location: Location,
         key_location: Location,
         associated_data: &[u8],
-    ) -> ClientResult<'_, reply::UnwrapFromFile, Self> {
+    ) -> ClientResult<'_, reply::UnwrapKeyFromFile, Self> {
         let associated_data =
             Bytes::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
-        self.request(request::UnwrapFromFile {
+        self.request(request::UnwrapKeyFromFile {
             mechanism,
             key,
             path,

--- a/src/client.rs
+++ b/src/client.rs
@@ -531,6 +531,54 @@ pub trait CryptoClient: PollClient {
             associated_data,
         })
     }
+
+    /// Wrap a key to a file
+    /// This enables wrapping keys that don't fit in the buffers used by
+    /// [`write_file`](FilesystemClient::write_file) and [`read_file`](FilesystemClient::read_file)
+    fn wrap_to_file(
+        &mut self,
+        mechanism: Mechanism,
+        wrapping_key: KeyId,
+        key: KeyId,
+        path: PathBuf,
+        location: Location,
+        associated_data: &[u8],
+    ) -> ClientResult<'_, reply::WrapToFile, Self> {
+        let associated_data =
+            Bytes::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
+        self.request(request::WrapToFile {
+            mechanism,
+            wrapping_key,
+            key,
+            path,
+            location,
+            associated_data,
+        })
+    }
+
+    /// Wrap a key to a file
+    /// This enables wrapping keys that don't fit in the buffers used by
+    /// [`write_file`](FilesystemClient::write_file) and [`read_file`](FilesystemClient::read_file)
+    fn unwrap_from_file(
+        &mut self,
+        mechanism: Mechanism,
+        key: KeyId,
+        path: PathBuf,
+        file_location: Location,
+        key_location: Location,
+        associated_data: &[u8],
+    ) -> ClientResult<'_, reply::UnwrapFromFile, Self> {
+        let associated_data =
+            Bytes::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
+        self.request(request::UnwrapFromFile {
+            mechanism,
+            key,
+            path,
+            file_location,
+            key_location,
+            associated_data,
+        })
+    }
 }
 
 /// Create counters, increment existing counters.

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -20,11 +20,11 @@ const WRAPPED_TO_FILE_LEN: usize = MAX_SERIALIZED_KEY_LENGTH + NONCE_LEN + TAG_L
 
 #[cfg(feature = "chacha8-poly1305")]
 impl super::Chacha8Poly1305 {
-    pub fn wrap_to_file(
+    pub fn wrap_key_to_file(
         keystore: &mut impl Keystore,
         filestore: &mut impl Filestore,
-        request: &request::WrapToFile,
-    ) -> Result<reply::WrapToFile, Error> {
+        request: &request::WrapKeyToFile,
+    ) -> Result<reply::WrapKeyToFile, Error> {
         use chacha20poly1305::aead::{AeadMutInPlace, KeyInit};
         use chacha20poly1305::ChaCha8Poly1305;
         use rand_core::RngCore as _;
@@ -51,14 +51,14 @@ impl super::Chacha8Poly1305 {
             .unwrap();
         data.extend_from_slice(&tag).unwrap();
         filestore.write(&request.path, request.location, &data)?;
-        Ok(reply::WrapToFile {})
+        Ok(reply::WrapKeyToFile {})
     }
 
-    pub fn unwrap_from_file(
+    pub fn unwrap_key_from_file(
         keystore: &mut impl Keystore,
         filestore: &mut impl Filestore,
-        request: &request::UnwrapFromFile,
-    ) -> Result<reply::UnwrapFromFile, Error> {
+        request: &request::UnwrapKeyFromFile,
+    ) -> Result<reply::UnwrapKeyFromFile, Error> {
         use chacha20poly1305::aead::{AeadMutInPlace, KeyInit};
         use chacha20poly1305::ChaCha8Poly1305;
         let mut data: Bytes<WRAPPED_TO_FILE_LEN> =
@@ -89,7 +89,7 @@ impl super::Chacha8Poly1305 {
             )
             .is_err()
         {
-            return Ok(reply::UnwrapFromFile { key: None });
+            return Ok(reply::UnwrapKeyFromFile { key: None });
         }
         let key = key::Key::try_deserialize(material)?;
         let info = key::Info {
@@ -102,7 +102,7 @@ impl super::Chacha8Poly1305 {
             info,
             &key.material,
         )?;
-        Ok(reply::UnwrapFromFile { key: Some(key) })
+        Ok(reply::UnwrapKeyFromFile { key: Some(key) })
     }
 }
 

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -1,5 +1,6 @@
 use crate::api::*;
 // use crate::config::*;
+use crate::config::MAX_SERIALIZED_KEY_LENGTH;
 use crate::error::Error;
 use crate::key;
 use crate::service::*;
@@ -15,6 +16,90 @@ const TOTAL_LEN: usize = KEY_LEN + NONCE_LEN;
 const TAG_LEN: usize = 16;
 const KIND: key::Kind = key::Kind::Symmetric(KEY_LEN);
 const KIND_NONCE: key::Kind = key::Kind::Symmetric32Nonce(NONCE_LEN);
+const WRAPPED_TO_FILE_LEN: usize = MAX_SERIALIZED_KEY_LENGTH + NONCE_LEN + TAG_LEN;
+
+#[cfg(feature = "chacha8-poly1305")]
+impl super::Chacha8Poly1305 {
+    pub fn wrap_to_file(
+        keystore: &mut impl Keystore,
+        filestore: &mut impl Filestore,
+        request: &request::WrapToFile,
+    ) -> Result<reply::WrapToFile, Error> {
+        use chacha20poly1305::aead::{AeadMutInPlace, KeyInit};
+        use chacha20poly1305::ChaCha8Poly1305;
+        use rand_core::RngCore as _;
+
+        let serialized_key = keystore.load_key(key::Secrecy::Secret, None, &request.key)?;
+
+        let mut data =
+            Bytes::<WRAPPED_TO_FILE_LEN>::from_slice(&serialized_key.serialize()).unwrap();
+        let material_len = data.len();
+        data.resize_default(material_len + NONCE_LEN).unwrap();
+        let (material, nonce) = data.split_at_mut(material_len);
+        keystore.rng().fill_bytes(nonce);
+        let nonce = (&*nonce).try_into().unwrap();
+
+        let key = keystore.load_key(key::Secrecy::Secret, Some(KIND), &request.wrapping_key)?;
+        let chachakey: [u8; KEY_LEN] = (&*key.material).try_into().unwrap();
+        let mut aead = ChaCha8Poly1305::new(&GenericArray::clone_from_slice(&chachakey));
+        let tag = aead
+            .encrypt_in_place_detached(
+                <&GenericArray<_, _> as From<&[u8; NONCE_LEN]>>::from(nonce),
+                &request.associated_data,
+                material,
+            )
+            .unwrap();
+        data.extend_from_slice(&tag).unwrap();
+        filestore.write(&request.path, request.location, &data)?;
+        Ok(reply::WrapToFile {})
+    }
+
+    pub fn unwrap_from_file(
+        keystore: &mut impl Keystore,
+        filestore: &mut impl Filestore,
+        request: &request::UnwrapFromFile,
+    ) -> Result<reply::UnwrapFromFile, Error> {
+        use chacha20poly1305::aead::{AeadMutInPlace, KeyInit};
+        use chacha20poly1305::ChaCha8Poly1305;
+        let mut data: Bytes<WRAPPED_TO_FILE_LEN> =
+            filestore.read(&request.path, request.file_location)?;
+        let data_len = data.len();
+        let (tmp, tag) = data.split_at_mut(data_len - TAG_LEN);
+        let tmp_len = tmp.len();
+        let (material, nonce) = tmp.split_at_mut(tmp_len - NONCE_LEN);
+
+        // Coerce to array
+        let nonce = (&*nonce).try_into().unwrap();
+        let tag = (&*tag).try_into().unwrap();
+
+        let key = keystore.load_key(key::Secrecy::Secret, Some(KIND), &request.key)?;
+        let chachakey: [u8; KEY_LEN] = (&*key.material).try_into().unwrap();
+        let mut aead = ChaCha8Poly1305::new(&GenericArray::clone_from_slice(&chachakey));
+        if aead
+            .decrypt_in_place_detached(
+                <&GenericArray<_, _> as From<&[u8; NONCE_LEN]>>::from(nonce),
+                &request.associated_data,
+                material,
+                <&GenericArray<_, _> as From<&[u8; TAG_LEN]>>::from(tag),
+            )
+            .is_err()
+        {
+            return Ok(reply::UnwrapFromFile { key: None });
+        }
+        let key = key::Key::try_deserialize(material)?;
+        let info = key::Info {
+            flags: key.flags,
+            kind: key.kind,
+        };
+        let key = keystore.store_key(
+            request.key_location,
+            key::Secrecy::Secret,
+            info,
+            &key.material,
+        )?;
+        Ok(reply::UnwrapFromFile { key: Some(key) })
+    }
+}
 
 #[cfg(feature = "chacha8-poly1305")]
 impl GenerateKey for super::Chacha8Poly1305 {

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -63,7 +63,12 @@ impl super::Chacha8Poly1305 {
         use chacha20poly1305::ChaCha8Poly1305;
         let mut data: Bytes<WRAPPED_TO_FILE_LEN> =
             filestore.read(&request.path, request.file_location)?;
+
         let data_len = data.len();
+        if data_len < TAG_LEN + NONCE_LEN {
+            error!("Attempt to unwrap file that doesn't contain a key");
+            return Err(Error::InvalidSerializedKey);
+        }
         let (tmp, tag) = data.split_at_mut(data_len - TAG_LEN);
         let tmp_len = tmp.len();
         let (material, nonce) = tmp.split_at_mut(tmp_len - NONCE_LEN);

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -25,7 +25,7 @@ impl super::Chacha8Poly1305 {
         filestore: &mut impl Filestore,
         request: &request::WrapKeyToFile,
     ) -> Result<reply::WrapKeyToFile, Error> {
-        use chacha20poly1305::aead::{AeadMutInPlace, KeyInit};
+        use chacha20poly1305::aead::{AeadMutInPlace, NewAead};
         use chacha20poly1305::ChaCha8Poly1305;
         use rand_core::RngCore as _;
 
@@ -59,7 +59,7 @@ impl super::Chacha8Poly1305 {
         filestore: &mut impl Filestore,
         request: &request::UnwrapKeyFromFile,
     ) -> Result<reply::UnwrapKeyFromFile, Error> {
-        use chacha20poly1305::aead::{AeadMutInPlace, KeyInit};
+        use chacha20poly1305::aead::{AeadMutInPlace, NewAead};
         use chacha20poly1305::ChaCha8Poly1305;
         let mut data: Bytes<WRAPPED_TO_FILE_LEN> =
             filestore.read(&request.path, request.file_location)?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -511,21 +511,21 @@ impl<P: Platform> ServiceResources<P> {
 
                 }.map(Reply::WrapKey)
             },
-            Request::WrapToFile(request) => {
+            Request::WrapKeyToFile(request) => {
                 match request.mechanism {
                     #[cfg(feature = "chacha8-poly1305")]
-                    Mechanism::Chacha8Poly1305 => mechanisms::Chacha8Poly1305::wrap_to_file(keystore, filestore, request),
+                    Mechanism::Chacha8Poly1305 => mechanisms::Chacha8Poly1305::wrap_key_to_file(keystore, filestore, request),
                     _ => Err(Error::MechanismNotAvailable),
 
-                }.map(Reply::WrapToFile)
+                }.map(Reply::WrapKeyToFile)
             },
-            Request::UnwrapFromFile(request) => {
+            Request::UnwrapKeyFromFile(request) => {
                 match request.mechanism {
                     #[cfg(feature = "chacha8-poly1305")]
-                    Mechanism::Chacha8Poly1305 => mechanisms::Chacha8Poly1305::unwrap_from_file(keystore, filestore, request),
+                    Mechanism::Chacha8Poly1305 => mechanisms::Chacha8Poly1305::unwrap_key_from_file(keystore, filestore, request),
                     _ => Err(Error::MechanismNotAvailable),
 
-                }.map(Reply::UnwrapFromFile)
+                }.map(Reply::UnwrapKeyFromFile)
             },
 
             Request::RequestUserConsent(request) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -511,6 +511,22 @@ impl<P: Platform> ServiceResources<P> {
 
                 }.map(Reply::WrapKey)
             },
+            Request::WrapToFile(request) => {
+                match request.mechanism {
+                    #[cfg(feature = "chacha8-poly1305")]
+                    Mechanism::Chacha8Poly1305 => mechanisms::Chacha8Poly1305::wrap_to_file(keystore, filestore, request),
+                    _ => Err(Error::MechanismNotAvailable),
+
+                }.map(Reply::WrapToFile)
+            },
+            Request::UnwrapFromFile(request) => {
+                match request.mechanism {
+                    #[cfg(feature = "chacha8-poly1305")]
+                    Mechanism::Chacha8Poly1305 => mechanisms::Chacha8Poly1305::unwrap_from_file(keystore, filestore, request),
+                    _ => Err(Error::MechanismNotAvailable),
+
+                }.map(Reply::UnwrapFromFile)
+            },
 
             Request::RequestUserConsent(request) => {
                 // assert_eq!(request.level, consent::Level::Normal);

--- a/tests/chacha.rs
+++ b/tests/chacha.rs
@@ -1,12 +1,31 @@
 #![cfg(feature = "virt")]
 
 use trussed::client::CryptoClient;
-use trussed::types::{KeySerialization, Location, Mechanism, PathBuf, StorageAttributes};
-use trussed::{syscall, try_syscall};
+use trussed::syscall;
+use trussed::types::{
+    KeyId, KeySerialization, Location::*, Mechanism, PathBuf, SignatureSerialization,
+    StorageAttributes,
+};
 
 mod client;
 
-use trussed::types::Location::*;
+fn assert_key_eq(key1: KeyId, key2: KeyId, client: &mut impl trussed::Client) {
+    let derivative1 = syscall!(client.sign(
+        Mechanism::HmacSha256,
+        key1,
+        &[],
+        SignatureSerialization::Raw
+    ))
+    .signature;
+    let derivative2 = syscall!(client.sign(
+        Mechanism::HmacSha256,
+        key2,
+        &[],
+        SignatureSerialization::Raw
+    ))
+    .signature;
+    assert_eq!(derivative1, derivative2);
+}
 
 #[test]
 fn chacha_wrapkey() {
@@ -15,12 +34,12 @@ fn chacha_wrapkey() {
         let key = syscall!(client.unsafe_inject_key(
             Mechanism::Aes256Cbc,
             b"12345678123456781234567812345678",
-            Location::Volatile,
+            Volatile,
             KeySerialization::Raw
         ))
         .key;
 
-        let key2 = syscall!(client.generate_key(Mechanism::X255, StorageAttributes::new())).key;
+        let key2 = syscall!(client.generate_secret_key(32, Volatile)).key;
 
         let wrapped =
             syscall!(client.wrap_key(Mechanism::Chacha8Poly1305, key, key2, &[])).wrapped_key;
@@ -31,7 +50,9 @@ fn chacha_wrapkey() {
             &[],
             StorageAttributes::new()
         ))
-        .key;
+        .key
+        .unwrap();
+        assert_key_eq(key2, unwrapped, client);
 
         let wrapped_ad =
             syscall!(client.wrap_key(Mechanism::Chacha8Poly1305, key, key2, b"abc")).wrapped_key;
@@ -44,14 +65,16 @@ fn chacha_wrapkey() {
         ))
         .key
         .is_none());
-        let _unwrapped = syscall!(client.unwrap_key(
+        let unwrapped2 = syscall!(client.unwrap_key(
             Mechanism::Chacha8Poly1305,
             key,
             wrapped_ad,
             b"abc",
             StorageAttributes::new()
         ))
-        .key;
+        .key
+        .unwrap();
+        assert_key_eq(key2, unwrapped2, client);
     });
 }
 
@@ -62,21 +85,21 @@ fn chacha_wraptofile() {
         let key = syscall!(client.unsafe_inject_key(
             Mechanism::Aes256Cbc,
             b"12345678123456781234567812345678",
-            Location::Volatile,
+            Volatile,
             KeySerialization::Raw
         ))
         .key;
 
         let path = PathBuf::from("test_file");
 
-        let key2 = syscall!(client.generate_key(Mechanism::X255, StorageAttributes::new())).key;
+        let key2 = syscall!(client.generate_secret_key(32, Volatile)).key;
 
         syscall!(client.wrap_to_file(
             Mechanism::Chacha8Poly1305,
             key,
             key2,
             path.clone(),
-            Location::Volatile,
+            Volatile,
             &[],
         ));
 
@@ -84,19 +107,20 @@ fn chacha_wraptofile() {
             Mechanism::Chacha8Poly1305,
             key,
             path.clone(),
-            Location::Volatile,
-            Location::Volatile,
+            Volatile,
+            Volatile,
             &[],
         ))
         .key
         .unwrap();
+        assert_key_eq(key2, unwrapped, client);
 
         syscall!(client.wrap_to_file(
             Mechanism::Chacha8Poly1305,
             key,
             key2,
             path.clone(),
-            Location::Volatile,
+            Volatile,
             b"some ad",
         ));
 
@@ -104,8 +128,8 @@ fn chacha_wraptofile() {
             Mechanism::Chacha8Poly1305,
             key,
             path.clone(),
-            Location::Volatile,
-            Location::Volatile,
+            Volatile,
+            Volatile,
             &[],
         ))
         .key
@@ -114,12 +138,13 @@ fn chacha_wraptofile() {
         let unwrapped = syscall!(client.unwrap_from_file(
             Mechanism::Chacha8Poly1305,
             key,
-            path.clone(),
-            Location::Volatile,
-            Location::Volatile,
+            path,
+            Volatile,
+            Volatile,
             b"some ad",
         ))
         .key
         .unwrap();
+        assert_key_eq(key2, unwrapped, client);
     });
 }

--- a/tests/chacha.rs
+++ b/tests/chacha.rs
@@ -1,0 +1,125 @@
+#![cfg(feature = "virt")]
+
+use trussed::client::CryptoClient;
+use trussed::types::{KeySerialization, Location, Mechanism, PathBuf, StorageAttributes};
+use trussed::{syscall, try_syscall};
+
+mod client;
+
+use trussed::types::Location::*;
+
+#[test]
+fn chacha_wrapkey() {
+    client::get(|client| {
+        // Way to get a compatible Symmetric32 key
+        let key = syscall!(client.unsafe_inject_key(
+            Mechanism::Aes256Cbc,
+            b"12345678123456781234567812345678",
+            Location::Volatile,
+            KeySerialization::Raw
+        ))
+        .key;
+
+        let key2 = syscall!(client.generate_key(Mechanism::X255, StorageAttributes::new())).key;
+
+        let wrapped =
+            syscall!(client.wrap_key(Mechanism::Chacha8Poly1305, key, key2, &[])).wrapped_key;
+        let unwrapped = syscall!(client.unwrap_key(
+            Mechanism::Chacha8Poly1305,
+            key,
+            wrapped,
+            &[],
+            StorageAttributes::new()
+        ))
+        .key;
+
+        let wrapped_ad =
+            syscall!(client.wrap_key(Mechanism::Chacha8Poly1305, key, key2, b"abc")).wrapped_key;
+        assert!(syscall!(client.unwrap_key(
+            Mechanism::Chacha8Poly1305,
+            key,
+            wrapped_ad.clone(),
+            &[],
+            StorageAttributes::new()
+        ))
+        .key
+        .is_none());
+        let _unwrapped = syscall!(client.unwrap_key(
+            Mechanism::Chacha8Poly1305,
+            key,
+            wrapped_ad,
+            b"abc",
+            StorageAttributes::new()
+        ))
+        .key;
+    });
+}
+
+#[test]
+fn chacha_wraptofile() {
+    client::get(|client| {
+        // Way to get a compatible Symmetric32 key
+        let key = syscall!(client.unsafe_inject_key(
+            Mechanism::Aes256Cbc,
+            b"12345678123456781234567812345678",
+            Location::Volatile,
+            KeySerialization::Raw
+        ))
+        .key;
+
+        let path = PathBuf::from("test_file");
+
+        let key2 = syscall!(client.generate_key(Mechanism::X255, StorageAttributes::new())).key;
+
+        syscall!(client.wrap_to_file(
+            Mechanism::Chacha8Poly1305,
+            key,
+            key2,
+            path.clone(),
+            Location::Volatile,
+            &[],
+        ));
+
+        let unwrapped = syscall!(client.unwrap_from_file(
+            Mechanism::Chacha8Poly1305,
+            key,
+            path.clone(),
+            Location::Volatile,
+            Location::Volatile,
+            &[],
+        ))
+        .key
+        .unwrap();
+
+        syscall!(client.wrap_to_file(
+            Mechanism::Chacha8Poly1305,
+            key,
+            key2,
+            path.clone(),
+            Location::Volatile,
+            b"some ad",
+        ));
+
+        assert!(syscall!(client.unwrap_from_file(
+            Mechanism::Chacha8Poly1305,
+            key,
+            path.clone(),
+            Location::Volatile,
+            Location::Volatile,
+            &[],
+        ))
+        .key
+        .is_none());
+
+        let unwrapped = syscall!(client.unwrap_from_file(
+            Mechanism::Chacha8Poly1305,
+            key,
+            path.clone(),
+            Location::Volatile,
+            Location::Volatile,
+            b"some ad",
+        ))
+        .key
+        .unwrap();
+    });
+}

--- a/tests/chacha.rs
+++ b/tests/chacha.rs
@@ -94,7 +94,7 @@ fn chacha_wraptofile() {
 
         let key2 = syscall!(client.generate_secret_key(32, Volatile)).key;
 
-        syscall!(client.wrap_to_file(
+        syscall!(client.wrap_key_to_file(
             Mechanism::Chacha8Poly1305,
             key,
             key2,
@@ -103,7 +103,7 @@ fn chacha_wraptofile() {
             &[],
         ));
 
-        let unwrapped = syscall!(client.unwrap_from_file(
+        let unwrapped = syscall!(client.unwrap_key_from_file(
             Mechanism::Chacha8Poly1305,
             key,
             path.clone(),
@@ -115,7 +115,7 @@ fn chacha_wraptofile() {
         .unwrap();
         assert_key_eq(key2, unwrapped, client);
 
-        syscall!(client.wrap_to_file(
+        syscall!(client.wrap_key_to_file(
             Mechanism::Chacha8Poly1305,
             key,
             key2,
@@ -124,7 +124,7 @@ fn chacha_wraptofile() {
             b"some ad",
         ));
 
-        assert!(syscall!(client.unwrap_from_file(
+        assert!(syscall!(client.unwrap_key_from_file(
             Mechanism::Chacha8Poly1305,
             key,
             path.clone(),
@@ -135,7 +135,7 @@ fn chacha_wraptofile() {
         .key
         .is_none());
 
-        let unwrapped = syscall!(client.unwrap_from_file(
+        let unwrapped = syscall!(client.unwrap_key_from_file(
             Mechanism::Chacha8Poly1305,
             key,
             path,


### PR DESCRIPTION
These syscall are required because RSA keys can get bigger than the data that can be transmitted through `wrap_key`.