### PR TITLE
Chunk api

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -50,7 +50,10 @@ generate_enums! {
     SerializeKey: 17
     Sign: 18
     WriteFile: 19
-    WriteChunk: 66
+    StartChunkedWrite: 66
+    WriteChunk: 67
+    FlushChunks: 68
+    AbortChunkedWrite: 69
     UnsafeInjectKey: 20
     UnsafeInjectSharedKey: 21
     UnwrapKey: 22
@@ -288,11 +291,23 @@ pub mod request {
           - data: Message
           - user_attribute: Option<UserAttribute>
 
+        StartChunkedWrite:
+          - location: Location
+          - path: PathBuf
+          - data: Message
+          - user_attribute: Option<UserAttribute>
+
         WriteChunk:
           - location: Location
           - pos: OpenSeekFrom
           - path: PathBuf
           - data: Message
+        FlushChunks:
+          - location: Location
+          - path: PathBuf
+        AbortChunkedWrite:
+          - location: Location
+          - path: PathBuf
 
         UnsafeInjectKey:
           - mechanism: Mechanism        // -> implies key type
@@ -469,7 +484,11 @@ pub mod reply {
             - signature: Signature
 
         WriteFile:
+        StartChunkedWrite:
         WriteChunk:
+        FlushChunks:
+        AbortChunkedWrite:
+            - aborted: bool
 
         Verify:
             - valid: bool

--- a/src/api.rs
+++ b/src/api.rs
@@ -43,12 +43,14 @@ generate_enums! {
     ReadDirFilesFirst: 13
     ReadDirFilesNext: 14
     ReadFile: 15
+    ReadChunk: 65
     Metadata: 26
     // ReadCounter: 7
     RandomBytes: 16
     SerializeKey: 17
     Sign: 18
     WriteFile: 19
+    WriteChunk: 66
     UnsafeInjectKey: 20
     UnsafeInjectSharedKey: 21
     UnwrapKey: 22
@@ -241,6 +243,10 @@ pub mod request {
         ReadFile:
           - location: Location
           - path: PathBuf
+        ReadChunk:
+          - location: Location
+          - pos: OpenSeekFrom
+          - path: PathBuf
 
         Metadata:
           - location: Location
@@ -281,6 +287,12 @@ pub mod request {
           - path: PathBuf
           - data: Message
           - user_attribute: Option<UserAttribute>
+
+        WriteChunk:
+          - location: Location
+          - pos: OpenSeekFrom
+          - path: PathBuf
+          - data: Message
 
         UnsafeInjectKey:
           - mechanism: Mechanism        // -> implies key type
@@ -430,6 +442,9 @@ pub mod reply {
 
         ReadFile:
           - data: Message
+        ReadChunk:
+          - data: Message
+          - len: usize
 
         Metadata:
           - metadata: Option<crate::types::Metadata>
@@ -454,6 +469,7 @@ pub mod reply {
             - signature: Signature
 
         WriteFile:
+        WriteChunk:
 
         Verify:
             - valid: bool

--- a/src/client.rs
+++ b/src/client.rs
@@ -622,6 +622,7 @@ pub trait FilesystemClient: PollClient {
         self.request(request::ReadFile { location, path })
     }
 
+    // Read part of a file, up to 1KiB starting at `pos`
     fn read_file_chunk(
         &mut self,
         location: Location,
@@ -674,6 +675,10 @@ pub trait FilesystemClient: PollClient {
         })
     }
 
+    /// Begin writing a file that can be larger than 1KiB
+    ///
+    /// More chunks can be written with [`write_file_chunk`](FilesystemClient::write_file_chunk).
+    /// Before the data becomes readable, it needs to be flushed with [`flush_chunks`](FilesystemClient::flush_chunks), or aborted with [`abort_chunked_write`](FilesystemClient::abort_chunked_write)
     fn start_chunked_write(
         &mut self,
         location: Location,
@@ -689,6 +694,9 @@ pub trait FilesystemClient: PollClient {
         })
     }
 
+    /// Write part of a file
+    ///
+    /// See [`start_chunked_write`](FilesystemClient::start_chunked_write).
     fn write_file_chunk(
         &mut self,
         location: Location,
@@ -703,6 +711,9 @@ pub trait FilesystemClient: PollClient {
             pos,
         })
     }
+
+    /// Flush a file opened with [`start_chunked_write`](FilesystemClient::start_chunked_write).
+    /// Only after this will the content of the file be readable
     fn flush_chunks(
         &mut self,
         location: Location,
@@ -711,6 +722,7 @@ pub trait FilesystemClient: PollClient {
         self.request(request::FlushChunks { location, path })
     }
 
+    /// Abort writes to a file opened with [`start_chunked_write`](FilesystemClient::start_chunked_write).
     fn abort_chunked_write(
         &mut self,
         location: Location,

--- a/src/client.rs
+++ b/src/client.rs
@@ -674,6 +674,21 @@ pub trait FilesystemClient: PollClient {
         })
     }
 
+    fn start_chunked_write(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+        data: Message,
+        user_attribute: Option<UserAttribute>,
+    ) -> ClientResult<'_, reply::StartChunkedWrite, Self> {
+        self.request(request::StartChunkedWrite {
+            location,
+            path,
+            data,
+            user_attribute,
+        })
+    }
+
     fn write_file_chunk(
         &mut self,
         location: Location,
@@ -687,6 +702,21 @@ pub trait FilesystemClient: PollClient {
             data,
             pos,
         })
+    }
+    fn flush_chunks(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+    ) -> ClientResult<'_, reply::FlushChunks, Self> {
+        self.request(request::FlushChunks { location, path })
+    }
+
+    fn abort_chunked_write(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+    ) -> ClientResult<'_, reply::AbortChunkedWrite, Self> {
+        self.request(request::AbortChunkedWrite { location, path })
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -622,6 +622,19 @@ pub trait FilesystemClient: PollClient {
         self.request(request::ReadFile { location, path })
     }
 
+    fn read_file_chunk(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+        pos: OpenSeekFrom,
+    ) -> ClientResult<'_, reply::ReadChunk, Self> {
+        self.request(request::ReadChunk {
+            location,
+            path,
+            pos,
+        })
+    }
+
     /// Fetch the Metadata for a file or directory
     ///
     /// If the file doesn't exists, return None
@@ -658,6 +671,21 @@ pub trait FilesystemClient: PollClient {
             path,
             data,
             user_attribute,
+        })
+    }
+
+    fn write_file_chunk(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+        data: Message,
+        pos: OpenSeekFrom,
+    ) -> ClientResult<'_, reply::WriteChunk, Self> {
+        self.request(request::WriteChunk {
+            location,
+            path,
+            data,
+            pos,
         })
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -679,6 +679,8 @@ pub trait FilesystemClient: PollClient {
     ///
     /// More chunks can be written with [`write_file_chunk`](FilesystemClient::write_file_chunk).
     /// Before the data becomes readable, it needs to be flushed with [`flush_chunks`](FilesystemClient::flush_chunks), or aborted with [`abort_chunked_write`](FilesystemClient::abort_chunked_write)
+    ///
+    /// Chunked writes are buffered in memory. Failing to abort or flush a chunked write will lead to a memory leak, that can be solved by a power cycle.
     fn start_chunked_write(
         &mut self,
         location: Location,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod serde_extensions;
 pub mod service;
 pub mod store;
 pub mod types;
+pub mod utils;
 
 #[cfg(feature = "virt")]
 #[cfg_attr(docsrs, doc(cfg(feature = "virt")))]

--- a/src/service.rs
+++ b/src/service.rs
@@ -490,9 +490,21 @@ impl<P: Platform> ServiceResources<P> {
                 filestore.write(&request.path, request.location, &request.data)?;
                 Ok(Reply::WriteFile(reply::WriteFile {} ))
             }
+            Request::StartChunkedWrite(request) => {
+                filestore.start_chunked_write(&request.path, request.location, &request.data)?;
+                Ok(Reply::StartChunkedWrite(reply::StartChunkedWrite {} ))
+            }
             Request::WriteChunk(request) => {
                  filestore.write_chunk(&request.path, request.location, &request.data,request.pos)?;
                 Ok(Reply::WriteChunk(reply::WriteChunk {} ))
+            }
+            Request::FlushChunks(request) => {
+                filestore.flush_chunks(&request.path, request.location)?;
+                Ok(Reply::FlushChunks(reply::FlushChunks {} ))
+            }
+            Request::AbortChunkedWrite(request) => {
+                let aborted = filestore.abort_chunked_write(&request.path, request.location);
+                Ok(Reply::AbortChunkedWrite(reply::AbortChunkedWrite {aborted} ))
             }
 
             Request::UnwrapKey(request) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -433,6 +433,14 @@ impl<P: Platform> ServiceResources<P> {
                 }))
             }
 
+            Request::ReadChunk(request) => {
+                let (data,len) = filestore.read_chunk(&request.path,request.location,request.pos)?;
+                Ok(Reply::ReadChunk(reply::ReadChunk {
+                    data,
+                    len,
+                }))
+            }
+
             Request::Metadata(request) => {
                 Ok(Reply::Metadata(reply::Metadata{
                     metadata: filestore.metadata(&request.path, request.location)?
@@ -481,6 +489,10 @@ impl<P: Platform> ServiceResources<P> {
             Request::WriteFile(request) => {
                 filestore.write(&request.path, request.location, &request.data)?;
                 Ok(Reply::WriteFile(reply::WriteFile {} ))
+            }
+            Request::WriteChunk(request) => {
+                 filestore.write_chunk(&request.path, request.location, &request.data,request.pos)?;
+                Ok(Reply::WriteChunk(reply::WriteChunk {} ))
             }
 
             Request::UnwrapKey(request) => {

--- a/src/store.rs
+++ b/src/store.rs
@@ -606,6 +606,21 @@ pub fn write_chunk(
     .map_err(|_| Error::FilesystemWriteFailure)
 }
 
+pub fn rename(
+    store: impl Store,
+    location: Location,
+    from_path: &Path,
+    to_path: &Path,
+) -> Result<(), Error> {
+    debug_now!("renaming {} to {}", from_path, to_path);
+    match location {
+        Location::Internal => store.ifs().rename(from_path, to_path),
+        Location::External => store.efs().rename(from_path, to_path),
+        Location::Volatile => store.vfs().rename(from_path, to_path),
+    }
+    .map_err(|_| Error::FilesystemWriteFailure)
+}
+
 /// Creates parent directory if necessary, then writes.
 #[inline(never)]
 pub fn store(

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@ use core::ops::Deref;
 pub use generic_array::GenericArray;
 
 pub use heapless::{String, Vec};
+use littlefs2::io::SeekFrom;
 
 pub use crate::Bytes;
 
@@ -617,3 +618,21 @@ pub enum SignatureSerialization {
 }
 
 pub type UserAttribute = Bytes<MAX_USER_ATTRIBUTE_LENGTH>;
+
+/// Enumeration of possible methods to seek within an file that was just opened
+/// Used in the [`read_chunk`](crate::store::read_chunk) and [`write_chunk`](crate::store::write_chunk) calls,
+/// Where [`SeekFrom::Current`](littlefs2::io::SeekFrom::Current) would not make sense.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum OpenSeekFrom {
+    Start(u32),
+    End(i32),
+}
+
+impl From<OpenSeekFrom> for SeekFrom {
+    fn from(value: OpenSeekFrom) -> Self {
+        match value {
+            OpenSeekFrom::Start(o) => Self::Start(o),
+            OpenSeekFrom::End(o) => Self::End(o),
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,73 @@
+use littlefs2::path::PathBuf;
+
+use crate::{
+    syscall, try_syscall,
+    types::{Location, Message, OpenSeekFrom, UserAttribute},
+    Client, Error,
+};
+
+/// Write a large file (can be larger than 1KiB)
+///
+/// This is a wrapper around the [chunked writes api](crate::client::FilesystemClient::start_chunked_write)
+pub fn write_all(
+    client: &mut impl Client,
+    location: Location,
+    path: PathBuf,
+    data: &[u8],
+    user_attribute: Option<UserAttribute>,
+) -> Result<(), Error> {
+    if let Ok(msg) = Message::from_slice(data) {
+        // Fast path for small files
+        try_syscall!(client.write_file(location, path, msg, user_attribute))?;
+        Ok(())
+    } else {
+        write_chunked(client, location, path, data, user_attribute)
+    }
+}
+
+fn write_chunked(
+    client: &mut impl Client,
+    location: Location,
+    path: PathBuf,
+    data: &[u8],
+    user_attribute: Option<UserAttribute>,
+) -> Result<(), Error> {
+    let res = write_chunked_inner(client, location, path.clone(), data, user_attribute);
+    if res.is_ok() {
+        try_syscall!(client.flush_chunks(location, path)).map(drop)
+    } else {
+        syscall!(client.abort_chunked_write(location, path));
+        res
+    }
+}
+
+fn write_chunked_inner(
+    client: &mut impl Client,
+    location: Location,
+    path: PathBuf,
+    data: &[u8],
+    user_attribute: Option<UserAttribute>,
+) -> Result<(), Error> {
+    let mut msg = Message::new();
+    let chunk_size = msg.capacity();
+    let mut chunks = data.chunks(chunk_size).map(|chunk| {
+        Message::from(
+            heapless::Vec::try_from(chunk)
+                .expect("Iteration over chunks yields maximum of chunk_size"),
+        )
+    });
+    msg = chunks.next().unwrap_or_default();
+    let mut written = msg.len();
+    try_syscall!(client.start_chunked_write(location, path.clone(), msg, user_attribute))?;
+    for chunk in chunks {
+        let off = written;
+        written += chunk.len();
+        try_syscall!(client.write_file_chunk(
+            location,
+            path.clone(),
+            chunk,
+            OpenSeekFrom::Start(off as u32)
+        ))?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
This API adds a streaming API to write large files.

It stores chunks in volatile memory, and then commits them to static memory when writing is over.