### PR TITLE
Fix compilation without default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Build
         run: cargo build --verbose --target ${{ matrix.target }}
 
+      - name: Check all targets without default features
+        run: cargo check --all-targets --no-default-features
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+
       - name: Check all targets with default features
         run: cargo check --all-targets
         if: matrix.target == 'x86_64-unknown-linux-gnu'

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,8 @@ cfg_if::cfg_if! {
         pub const MAX_SERVICE_CLIENTS: usize = 2;
     } else if #[cfg(feature = "clients-1")] {
         pub const MAX_SERVICE_CLIENTS: usize = 1;
+    } else {
+        pub const MAX_SERVICE_CLIENTS: usize = 0;
     }
 }
 pub const MAX_SHORT_DATA_LENGTH: usize = 128;

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -167,9 +167,9 @@ impl UnsafeInjectKey for super::Aes256Cbc {
 
 #[cfg(not(feature = "aes256-cbc"))]
 impl UnsafeInjectKey for super::Aes256Cbc {}
-
 #[cfg(not(feature = "aes256-cbc"))]
 impl Decrypt for super::Aes256Cbc {}
-
 #[cfg(not(feature = "aes256-cbc"))]
 impl Encrypt for super::Aes256Cbc {}
+#[cfg(not(feature = "aes256-cbc"))]
+impl WrapKey for super::Aes256Cbc {}

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -245,8 +245,12 @@ impl UnwrapKey for super::Chacha8Poly1305 {
 }
 
 #[cfg(not(feature = "chacha8-poly1305"))]
-impl<P: Platform> Decrypt<P> for super::Chacha8Poly1305 {}
+impl Decrypt for super::Chacha8Poly1305 {}
 #[cfg(not(feature = "chacha8-poly1305"))]
-impl<P: Platform> Encrypt<P> for super::Chacha8Poly1305 {}
+impl Encrypt for super::Chacha8Poly1305 {}
 #[cfg(not(feature = "chacha8-poly1305"))]
-impl<P: Platform> GenerateKey<P> for super::Chacha8Poly1305 {}
+impl WrapKey for super::Chacha8Poly1305 {}
+#[cfg(not(feature = "chacha8-poly1305"))]
+impl UnwrapKey for super::Chacha8Poly1305 {}
+#[cfg(not(feature = "chacha8-poly1305"))]
+impl GenerateKey for super::Chacha8Poly1305 {}

--- a/src/mechanisms/ed255.rs
+++ b/src/mechanisms/ed255.rs
@@ -266,12 +266,16 @@ impl UnsafeInjectKey for super::Ed255 {
 }
 
 #[cfg(not(feature = "ed255"))]
+impl Exists for super::Ed255 {}
+#[cfg(not(feature = "ed255"))]
 impl DeriveKey for super::Ed255 {}
 #[cfg(not(feature = "ed255"))]
 impl GenerateKey for super::Ed255 {}
 #[cfg(not(feature = "ed255"))]
+impl SerializeKey for super::Ed255 {}
+#[cfg(not(feature = "ed255"))]
+impl DeserializeKey for super::Ed255 {}
+#[cfg(not(feature = "ed255"))]
 impl Sign for super::Ed255 {}
 #[cfg(not(feature = "ed255"))]
 impl Verify for super::Ed255 {}
-#[cfg(not(feature = "ed255"))]
-impl UnsafeInjectKey for super::ed255 {}

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -373,12 +373,18 @@ impl UnsafeInjectKey for super::P256 {
 #[cfg(not(feature = "p256"))]
 impl Agree for super::P256 {}
 #[cfg(not(feature = "p256"))]
+impl Exists for super::P256 {}
+#[cfg(not(feature = "p256"))]
 impl DeriveKey for super::P256 {}
 #[cfg(not(feature = "p256"))]
 impl GenerateKey for super::P256 {}
 #[cfg(not(feature = "p256"))]
+impl DeserializeKey for super::P256 {}
+#[cfg(not(feature = "p256"))]
+impl SerializeKey for super::P256 {}
+#[cfg(not(feature = "p256"))]
 impl Sign for super::P256 {}
 #[cfg(not(feature = "p256"))]
-impl Verify for super::P256 {}
+impl Sign for super::P256Prehashed {}
 #[cfg(not(feature = "p256"))]
-impl UnsafeInjectKey for super::P256 {}
+impl Verify for super::P256 {}

--- a/src/mechanisms/tdes.rs
+++ b/src/mechanisms/tdes.rs
@@ -6,6 +6,7 @@
 // use cortex_m_semihosting::{dbg, hprintln};
 
 // needed to even get ::new() from des...
+#[cfg(feature = "tdes")]
 use des::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 
 use crate::api::*;
@@ -109,3 +110,9 @@ impl UnsafeInjectKey for super::Tdes {
         Ok(reply::UnsafeInjectKey { key: key_id })
     }
 }
+
+#[cfg(not(feature = "tdes"))]
+impl Encrypt for super::Tdes {}
+
+#[cfg(not(feature = "tdes"))]
+impl Decrypt for super::Tdes {}

--- a/src/mechanisms/totp.rs
+++ b/src/mechanisms/totp.rs
@@ -9,11 +9,13 @@ const TOTP_KEY_SIZE: usize = 20;
 
 // https://tools.ietf.org/html/rfc4226#section-5.3
 
+#[cfg(feature = "totp")]
 #[inline(never)]
 fn hotp_raw(key: &[u8], counter: u64, digits: u32) -> u64 {
     hmac_and_truncate(key, &counter.to_be_bytes(), digits)
 }
 
+#[cfg(feature = "totp")]
 #[inline(never)]
 fn hmac_and_truncate(key: &[u8], message: &[u8], digits: u32) -> u64 {
     use hmac::{Hmac, Mac};
@@ -91,7 +93,12 @@ impl Exists for super::Totp {
     }
 }
 
-#[cfg(test)]
+#[cfg(not(feature = "totp"))]
+impl Sign for super::Totp {}
+#[cfg(not(feature = "totp"))]
+impl Exists for super::Totp {}
+
+#[cfg(all(test, feature = "totp"))]
 mod tests {
     use super::*;
 

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -235,10 +235,8 @@ impl GenerateKey for super::X255 {}
 #[cfg(not(feature = "x255"))]
 impl Exists for super::X255 {}
 #[cfg(not(feature = "x255"))]
-impl Derive for super::X255 {}
+impl DeriveKey for super::X255 {}
 #[cfg(not(feature = "x255"))]
 impl SerializeKey for super::X255 {}
 #[cfg(not(feature = "x255"))]
 impl DeserializeKey for super::X255 {}
-#[cfg(not(feature = "x255"))]
-impl UnsafeInjectKey for super::X255 {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -202,6 +202,7 @@ fn dummy() {
     setup!(_client);
 }
 
+#[cfg(feature = "ed255")]
 #[test]
 #[serial]
 fn sign_ed255() {
@@ -255,6 +256,7 @@ fn sign_ed255() {
     assert_eq!(Err(Error::WrongSignatureLength), reply);
 }
 
+#[cfg(feature = "p255")]
 #[test]
 #[serial]
 fn sign_p256() {
@@ -294,6 +296,7 @@ fn sign_p256() {
     assert!(valid);
 }
 
+#[cfg(feature = "p255")]
 #[test]
 #[serial]
 fn agree_p256() {
@@ -376,6 +379,7 @@ fn agree_p256() {
     .signature;
 }
 
+#[cfg(feature = "chacha8-poly1305")]
 #[test]
 #[serial]
 fn aead_rng_nonce() {
@@ -412,6 +416,7 @@ fn aead_rng_nonce() {
     assert_eq!(&message[..], plaintext.unwrap().as_ref());
 }
 
+#[cfg(feature = "chacha8-poly1305")]
 #[test]
 #[serial]
 fn aead_given_nonce() {
@@ -450,6 +455,7 @@ fn aead_given_nonce() {
 }
 
 // Same as before but key generated with a nonce
+#[cfg(feature = "chacha8-poly1305")]
 #[test]
 #[serial]
 fn aead_given_nonce_2() {
@@ -487,6 +493,7 @@ fn aead_given_nonce_2() {
     assert_eq!(&message[..], plaintext.unwrap().as_ref());
 }
 
+#[cfg(feature = "chacha8-poly1305")]
 #[test]
 #[serial]
 fn aead() {


### PR DESCRIPTION
This patch fixes the compilation of all targets if the default features are disabled and adds a CI job that checks this.

Fixes: https://github.com/trussed-dev/trussed/issues/90