### PR TITLE
Remove restoration of ui status after RequestUserPresence call

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -523,7 +523,6 @@ impl<P: Platform> ServiceResources<P> {
                 let timeout =
                     core::time::Duration::from_millis(request.timeout_milliseconds as u64);
 
-                let previous_status = self.platform.user_interface().status();
                 self.platform
                     .user_interface()
                     .set_status(ui::Status::WaitingForUserPresence);
@@ -564,7 +563,6 @@ impl<P: Platform> ServiceResources<P> {
                         }
                     }
                 }
-                self.platform.user_interface().set_status(previous_status);
 
                 let result = Ok(());
                 Ok(Reply::RequestUserConsent(reply::RequestUserConsent {


### PR DESCRIPTION
The `reply_to` method always restores the status to Idle anyway after the syscall returns

Close #129