### PR TITLE
Update to salty 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ heapless-bytes = { version = "0.3.0", features = ["cbor"] }
 interchange = "0.3.0"
 littlefs2 = "0.4.0"
 p256-cortex-m4 = { version = "0.1.0-alpha.6", features = ["prehash", "sec1-signatures"] }
-salty = { version = "0.2.0", features = ["cose"] }
+salty = { version = "0.3.0", features = ["cose"] }
 serde-indexed = "0.1.0"
 
 [dev-dependencies]

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -1,4 +1,4 @@
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryInto;
 
 use crate::api::*;
 // use crate::config::*;
@@ -20,8 +20,7 @@ fn load_public_key(
         .try_into()
         .map_err(|_| Error::InternalError)?;
 
-    let public_key =
-        agreement::PublicKey::try_from(public_bytes).map_err(|_| Error::InternalError)?;
+    let public_key = public_bytes.into();
 
     Ok(public_key)
 }
@@ -186,8 +185,8 @@ impl DeserializeKey for super::X255 {
         }
 
         let serialized_key: [u8; 32] = request.serialized_key[..32].try_into().unwrap();
-        let public_key = salty::agreement::PublicKey::try_from(serialized_key)
-            .map_err(|_| Error::InvalidSerializedKey)?;
+        // This will make it store the canonical encoding
+        let public_key: agreement::PublicKey = serialized_key.into();
 
         let public_id = keystore.store_key(
             request.attributes.persistence,

--- a/tests/x255.rs
+++ b/tests/x255.rs
@@ -41,3 +41,15 @@ fn x255_agree() {
             syscall!(client.serialize_key(Mechanism::SharedSecret, secret2, KeySerialization::Raw));
     })
 }
+
+#[test]
+fn x255_non_canonical() {
+    client::get(|client| {
+        let _pk1 = syscall!(client.deserialize_key(
+            Mechanism::X255,
+            &[0xFF; 32],
+            KeySerialization::Raw,
+            StorageAttributes::new().set_serializable(true)
+        ));
+    })
+}


### PR DESCRIPTION
This fixes a limitiation where trussed refused to deserialize a non-canonical but valid X255 key