### PR TITLE
Access the keystore via a path rather than the CoreContext

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -115,9 +115,9 @@ impl<P: Platform> ServiceResources<P> {
         ClientFilestore::new(PathBuf::from("trussed"), self.platform.store())
     }
 
-    pub fn keystore(&mut self, ctx: &CoreContext) -> Result<ClientKeystore<P::S>> {
+    pub fn keystore(&mut self, client_id: PathBuf) -> Result<ClientKeystore<P::S>> {
         self.rng()
-            .map(|rng| ClientKeystore::new(ctx.path.clone(), rng, self.platform.store()))
+            .map(|rng| ClientKeystore::new(client_id, rng, self.platform.store()))
             .map_err(|_| Error::EntropyMalfunction)
     }
 
@@ -141,7 +141,7 @@ impl<P: Platform> ServiceResources<P> {
 
         let full_store = self.platform.store();
 
-        let keystore = &mut self.keystore(ctx)?;
+        let keystore = &mut self.keystore(ctx.path.clone())?;
         let certstore = &mut self.certstore(ctx)?;
         let counterstore = &mut self.counterstore(ctx)?;
         let filestore = &mut self.filestore(ctx.path.clone());


### PR DESCRIPTION
Similar to 5af424e7ecb25832e003fc7451eff5ca010dae1e, this patch updates the `keystore` method to be able to create a keystore with a custom path. This can be useful for backends that want to have a keystore distinct from the core one.