### PR TITLE
Add `Clear` syscall

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -31,6 +31,11 @@ generate_enums! {
     DeserializeKey: 5
     Encrypt: 6
     Delete: 7
+    // Clear private data from the key
+    // This will not always delete all metadata from storage.
+    // Other backends can retain metadata required for `unwrap_key` to work properly
+    // and delete this metadata only once `delete` is called.
+    Clear: 63
     DeleteAllKeys: 25
     Exists: 8
     // DeriveKeypair: 3
@@ -148,6 +153,9 @@ pub mod request {
           - tag: ShortData
 
         Delete:
+          - key: KeyId
+
+        Clear:
           - key: KeyId
 
         DeleteAllKeys:
@@ -381,6 +389,9 @@ pub mod reply {
             - plaintext: Option<Message>
 
         Delete:
+            - success: bool
+
+        Clear:
             - success: bool
 
         DeleteAllKeys:

--- a/src/client.rs
+++ b/src/client.rs
@@ -347,6 +347,18 @@ pub trait CryptoClient: PollClient {
         })
     }
 
+    /// Clear private data from the key
+    ///
+    /// This will not delete all metadata from storage.
+    /// Other backends can retain metadata required for `unwrap_key` to work properly
+    /// and delete this metadata only once `delete` is called.
+    fn clear(&mut self, key: KeyId) -> ClientResult<'_, reply::Clear, Self> {
+        self.request(request::Clear {
+            key,
+            // mechanism,
+        })
+    }
+
     /// Skips deleting read-only / manufacture keys (currently, "low ID").
     fn delete_all(&mut self, location: Location) -> ClientResult<'_, reply::DeleteAllKeys, Self> {
         self.request(request::DeleteAllKeys { location })

--- a/src/service.rs
+++ b/src/service.rs
@@ -225,6 +225,11 @@ impl<P: Platform> ServiceResources<P> {
                 Ok(Reply::Delete(reply::Delete { success } ))
             },
 
+            Request::Clear(request) => {
+                let success = keystore.clear_key(&request.key);
+                Ok(Reply::Clear(reply::Clear { success } ))
+            },
+
             Request::DeleteAllKeys(request) => {
                 let count = keystore.delete_all(request.location)?;
                 Ok(Reply::DeleteAllKeys(reply::DeleteAllKeys { count } ))

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -52,6 +52,7 @@ pub trait Keystore {
     /// Return Header of key, if it exists
     fn key_info(&self, secrecy: key::Secrecy, id: &KeyId) -> Option<key::Info>;
     fn delete_key(&self, id: &KeyId) -> bool;
+    fn clear_key(&self, id: &KeyId) -> bool;
     fn delete_all(&self, location: Location) -> Result<usize>;
     fn load_key(
         &self,
@@ -150,6 +151,10 @@ impl<S: Store> Keystore for ClientKeystore<S> {
                 .iter()
                 .any(|location| store::delete(self.store, *location, &path))
         })
+    }
+
+    fn clear_key(&self, id: &KeyId) -> bool {
+        self.delete_key(id)
     }
 
     /// TODO: This uses the predicate "filename.len() >= 4"


### PR DESCRIPTION
This syscall does the same as `delete` for a key.
The only difference is that it is designed to allow re-import of the key if it was exported with `WrapKey`.

With the core trussed backend this does not change anything, as nothing is needed to allow the re-import. However the same mechansim in the SE050 work differently, and being able to differenciate permanent deletion and deletion with intent to re-import is crucial.