### PR TITLE
Make more APIs public

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -21,6 +21,7 @@ use crate::{
 ///
 /// This ID can refer to the core backend provided by the Trussed crate, or to a custom backend
 /// defined by the runner.  The custom ID type is defined by [`Dispatch::BackendId`][].
+#[derive(Debug, Clone)]
 pub enum BackendId<I> {
     Core,
     Custom(I),

--- a/src/types.rs
+++ b/src/types.rs
@@ -169,6 +169,11 @@ impl KeyId {
     pub fn from_value(value: u128) -> Self {
         Self(Id(value))
     }
+
+    #[doc(hidden)]
+    pub fn value(&self) -> u128 {
+        self.0 .0
+    }
 }
 
 // TODO: decide whether this is good idea.

--- a/src/types.rs
+++ b/src/types.rs
@@ -158,6 +158,19 @@ macro_rules! impl_id {
 impl_id!(CertId);
 impl_id!(CounterId);
 impl_id!(KeyId);
+
+impl KeyId {
+    /// Create a KeyId from a given value instead of at random.
+    ///
+    /// This can be useful for backends which can use it to encode additional information inside of the KeyId itself (128 bits is a lot)
+    ///
+    /// This is already possible to acheive through the serde implementation, so this doesn't really add any unavailable functionality.
+    #[doc(hidden)]
+    pub fn from_value(value: u128) -> Self {
+        Self(Id(value))
+    }
+}
+
 // TODO: decide whether this is good idea.
 // It would allow using the same underlying u128 ID for the public key of the private
 // key in a keypair. However, DeleteKey and others would need to be adjusted.


### PR DESCRIPTION
These APIs improve debugging or are required for custom backend implementations.

Built on top of #139  that will need to be merged first.

- Add debug implementations to `BackendId` and make it `Clone`. This allows better debugging.
- Add methods to read the u128 backing a `KeyId` and reading it. This can already be done through the `serde` implementation. This makes it possible to a custom backend to encode informations  so that it can differentiate between keys from the `core` backend and keys it generated itself.