### PR TITLE
Put unused syscalls behind features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `postcard_deserialize`, `postcard_serialize` and
   `postcard_serialize_bytes` private.
 - Changed `&PathBuf` to `&Path` where possible.
+- Put `CounterClient` and `CryptoClient::attest` behind feature flags (enabled
+  by default).
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde_cbor = { feature = "0.11.2", features = ["std"] }
 # rand_core = { version = "0.5", features = ["getrandom"] }
 
 [features]
-default = ["default-mechanisms", "clients-5"]
+default = ["default-mechanisms", "default-syscalls", "clients-5"]
 serde-extensions = []
 std = []
 verbose-tests = ["littlefs2/ll-assertions"]
@@ -75,7 +75,6 @@ log-warn = []
 log-error = []
 
 # mechanisms
-# default-mechanisms = ["aes256-cbc", "chacha8-poly1305", "ed255", "hmac-sha256", "p256", "sha256", "trng"]
 default-mechanisms = [
     "aes256-cbc",
     "chacha8-poly1305",
@@ -106,6 +105,11 @@ sha256 = []
 tdes = ["des"]
 totp = ["sha-1"]
 trng = ["sha-1"]
+
+# syscalls
+default-syscalls = ["counter-client", "crypto-client-attest"]
+counter-client = []
+crypto-client-attest = []
 
 clients-1 = []
 clients-2 = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -305,6 +305,7 @@ pub trait CryptoClient: PollClient {
         })
     }
 
+    #[cfg(feature = "crypto-client-attest")]
     fn attest(
         &mut self,
         signing_mechanism: Mechanism,
@@ -568,6 +569,7 @@ pub trait CryptoClient: PollClient {
 
 /// Create counters, increment existing counters.
 pub trait CounterClient: PollClient {
+    #[cfg(feature = "counter-client")]
     fn create_counter(
         &mut self,
         location: Location,
@@ -575,6 +577,7 @@ pub trait CounterClient: PollClient {
         self.request(request::CreateCounter { location })
     }
 
+    #[cfg(feature = "counter-client")]
     fn increment_counter(
         &mut self,
         id: CounterId,

--- a/tests/counter.rs
+++ b/tests/counter.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "virt")]
+#![cfg(feature = "counter-client")]
 
 mod client;
 mod store;


### PR DESCRIPTION
CounterClient and CryptoClient::attest are not currently used by the
solo2 or nk3 firmwares, but due to the indirect dispatch of Trussed
requests, they cannot be optimized out by the linker.  This patch
introduces feature flags for these syscalls that are enabled by default.