### PR TITLE
 Remove type parameters from Store 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,6 @@ test-attestation-cert-ids = []
 [package.metadata.docs.rs]
 features = ["serde-extensions", "virt"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }

--- a/src/service.rs
+++ b/src/service.rs
@@ -15,10 +15,12 @@ pub use crate::pipe::ServiceEndpoint;
 use crate::pipe::TrussedResponder;
 use crate::platform::*;
 pub use crate::store::{
+    self,
     certstore::{Certstore as _, ClientCertstore},
     counterstore::{ClientCounterstore, Counterstore as _},
     filestore::{ClientFilestore, Filestore, ReadDirFilesState, ReadDirState},
     keystore::{ClientKeystore, Keystore},
+    DynFilesystem,
 };
 use crate::types::ui::Status;
 use crate::types::*;
@@ -324,14 +326,14 @@ impl<P: Platform> ServiceResources<P> {
             Request::DebugDumpStore(_request) => {
 
                 info_now!(":: PERSISTENT");
-                recursively_list(self.platform.store().ifs(), path!("/"));
+                recursively_list(self.platform.store().fs(Location::Internal), path!("/"));
 
                 info_now!(":: VOLATILE");
-                recursively_list(self.platform.store().vfs(), path!("/"));
+                recursively_list(self.platform.store().fs(Location::Volatile), path!("/"));
 
-                fn recursively_list<S: 'static + crate::types::LfsStorage>(fs: &'static crate::store::Fs<S>, path: &Path) {
+                fn recursively_list(fs: &dyn DynFilesystem, path: &Path) {
                     // let fs = store.vfs();
-                    fs.read_dir_and_then(path, |dir| {
+                    fs.read_dir_and_then(path, &mut |dir| {
                         for (i, entry) in dir.enumerate() {
                             let entry = entry.unwrap();
                             if i < 2 {
@@ -343,7 +345,7 @@ impl<P: Platform> ServiceResources<P> {
                                 recursively_list(fs, entry.path());
                             }
                             if entry.file_type().is_file() {
-                                let _contents: Vec<u8, 256> = fs.read(entry.path()).unwrap();
+                                let _contents = fs.read::<256>(entry.path()).unwrap();
                                 // info_now!("{} ?= {}", entry.metadata().len(), contents.len()).ok();
                                 // info_now!("{:?}", &contents).ok();
                             }
@@ -869,19 +871,19 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
             self.resources
                 .platform
                 .store()
-                .ifs()
+                .fs(Location::Internal)
                 .available_blocks()
                 .unwrap(),
             self.resources
                 .platform
                 .store()
-                .efs()
+                .fs(Location::External)
                 .available_blocks()
                 .unwrap(),
             self.resources
                 .platform
                 .store()
-                .vfs()
+                .fs(Location::Volatile)
                 .available_blocks()
                 .unwrap(),
         );

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -1,7 +1,4 @@
-use littlefs2::{
-    path,
-    path::{Path, PathBuf},
-};
+use littlefs2::{path, path::PathBuf};
 use rand_chacha::ChaCha8Rng;
 
 use crate::{

--- a/src/store/counterstore.rs
+++ b/src/store/counterstore.rs
@@ -1,7 +1,4 @@
-use littlefs2::{
-    path,
-    path::{Path, PathBuf},
-};
+use littlefs2::{path, path::PathBuf};
 use rand_chacha::ChaCha8Rng;
 
 use crate::{

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::{Error, Result},
     // service::ReadDirState,
-    store::{self, Store},
-    types::{LfsStorage, Location, Message, UserAttribute},
+    store::{self, DynFilesystem, Store},
+    types::{Location, Message, UserAttribute},
     Bytes,
 };
 use littlefs2::path;
@@ -27,7 +27,6 @@ use littlefs2::{
     path::{Path, PathBuf},
 };
 
-use super::Fs;
 pub type ClientId = PathBuf;
 
 pub struct ClientFilestore<S>
@@ -142,17 +141,17 @@ pub trait Filestore {
 
 /// Generic implementation allowing the use of any filesystem.
 impl<S: Store> ClientFilestore<S> {
-    fn read_dir_first_impl<F: LfsStorage + 'static>(
+    fn read_dir_first_impl(
         &mut self,
         clients_dir: &Path,
         location: Location,
         not_before: Option<&Path>,
-        fs: &'static Fs<F>,
     ) -> Result<Option<(DirEntry, ReadDirState)>> {
+        let fs = self.store.fs(location);
         let dir = self.actual_path(clients_dir)?;
 
         Ok(fs
-            .read_dir_and_then(&dir, |it| {
+            .read_dir_and_then(&dir, &mut |it| {
                 // this is an iterator with Item = (usize, Result<DirEntry>)
                 it.enumerate()
                     // skip over `.` and `..`
@@ -197,21 +196,22 @@ impl<S: Store> ClientFilestore<S> {
             })
             .ok())
     }
-    fn read_dir_next_impl<F: LfsStorage + 'static>(
+    fn read_dir_next_impl(
         &mut self,
         state: ReadDirState,
-        fs: &'static Fs<F>,
     ) -> Result<Option<(DirEntry, ReadDirState)>> {
+        // TODO: check what happens (or used to happen) for FS != IFS
         let ReadDirState {
             real_dir,
             last,
             location,
         } = state;
+        let fs = self.store.fs(location);
 
         // all we want to do here is skip just past the previously found entry
         // in the directory iterator, then return it (plus state to continue on next call)
         Ok(fs
-            .read_dir_and_then(&real_dir, |it| {
+            .read_dir_and_then(&real_dir, &mut |it| {
                 // skip over previous
                 it.enumerate()
                     .nth(last + 1)
@@ -234,17 +234,17 @@ impl<S: Store> ClientFilestore<S> {
             })
             .ok())
     }
-    fn read_dir_files_first_impl<F: LfsStorage + 'static>(
+    fn read_dir_files_first_impl(
         &mut self,
         clients_dir: &Path,
         location: Location,
         user_attribute: Option<UserAttribute>,
-        fs: &'static Fs<F>,
     ) -> Result<Option<(Option<Message>, ReadDirFilesState)>> {
+        let fs = self.store.fs(location);
         let dir = self.actual_path(clients_dir)?;
 
         Ok(fs
-            .read_dir_and_then(&dir, |it| {
+            .read_dir_and_then(&dir, &mut |it| {
                 // this is an iterator with Item = (usize, Result<DirEntry>)
                 it.enumerate()
                     // todo: try ?-ing out of this (the API matches std::fs, where read/write errors
@@ -280,7 +280,8 @@ impl<S: Store> ClientFilestore<S> {
                             real_dir: dir.clone(),
                             last: i,
                             location,
-                            user_attribute,
+                            // TODO: check if we can avoid that clone
+                            user_attribute: user_attribute.clone(),
                         };
                         // The semantics is that for a non-existent file, we return None (not an error)
                         let data = store::read(self.store, location, entry.path()).ok();
@@ -295,22 +296,23 @@ impl<S: Store> ClientFilestore<S> {
             .ok())
     }
 
-    fn read_dir_files_next_impl<F: LfsStorage + 'static>(
+    fn read_dir_files_next_impl(
         &mut self,
         state: ReadDirFilesState,
-        fs: &'static Fs<F>,
     ) -> Result<Option<(Option<Message>, ReadDirFilesState)>> {
+        // TODO: check what happens (or used to happen) for FS != IFS
         let ReadDirFilesState {
             real_dir,
             last,
             location,
             user_attribute,
         } = state;
+        let fs = self.store.fs(location);
 
         // all we want to do here is skip just past the previously found entry
         // in the directory iterator, then return it (plus state to continue on next call)
         Ok(fs
-            .read_dir_and_then(&real_dir, |it| {
+            .read_dir_and_then(&real_dir, &mut |it| {
                 // skip over previous
                 it.enumerate()
                     .skip(last + 1)
@@ -340,7 +342,8 @@ impl<S: Store> ClientFilestore<S> {
                             real_dir: real_dir.clone(),
                             last: i,
                             location,
-                            user_attribute,
+                            // TODO: check if we can avoid that clone
+                            user_attribute: user_attribute.clone(),
                         };
                         // The semantics is that for a non-existent file, we return None (not an error)
                         let data = store::read(self.store, location, entry.path()).ok();
@@ -404,7 +407,7 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     fn remove_dir_all(&mut self, path: &Path, location: Location) -> Result<usize> {
         let path = self.actual_path(path)?;
 
-        store::remove_dir_all_where(self.store, location, &path, |_| true)
+        store::remove_dir_all_where(self.store, location, &path, &|_| true)
             .map_err(|_| Error::InternalError)
     }
     fn remove_dir_all_where(
@@ -415,7 +418,7 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     ) -> Result<usize> {
         let path = self.actual_path(path)?;
 
-        store::remove_dir_all_where(self.store, location, &path, predicate)
+        store::remove_dir_all_where(self.store, location, &path, &predicate)
             .map_err(|_| Error::InternalError)
     }
 
@@ -425,25 +428,11 @@ impl<S: Store> Filestore for ClientFilestore<S> {
         location: Location,
         not_before: Option<&Path>,
     ) -> Result<Option<(DirEntry, ReadDirState)>> {
-        match location {
-            Location::Internal => {
-                self.read_dir_first_impl(clients_dir, location, not_before, self.store.ifs())
-            }
-            Location::External => {
-                self.read_dir_first_impl(clients_dir, location, not_before, self.store.efs())
-            }
-            Location::Volatile => {
-                self.read_dir_first_impl(clients_dir, location, not_before, self.store.vfs())
-            }
-        }
+        self.read_dir_first_impl(clients_dir, location, not_before)
     }
 
     fn read_dir_next(&mut self, state: ReadDirState) -> Result<Option<(DirEntry, ReadDirState)>> {
-        match state.location {
-            Location::Internal => self.read_dir_next_impl(state, self.store.ifs()),
-            Location::External => self.read_dir_next_impl(state, self.store.efs()),
-            Location::Volatile => self.read_dir_next_impl(state, self.store.vfs()),
-        }
+        self.read_dir_next_impl(state)
     }
 
     fn read_dir_files_first(
@@ -452,37 +441,14 @@ impl<S: Store> Filestore for ClientFilestore<S> {
         location: Location,
         user_attribute: Option<UserAttribute>,
     ) -> Result<Option<(Option<Message>, ReadDirFilesState)>> {
-        match location {
-            Location::Internal => self.read_dir_files_first_impl(
-                clients_dir,
-                location,
-                user_attribute,
-                self.store.ifs(),
-            ),
-            Location::External => self.read_dir_files_first_impl(
-                clients_dir,
-                location,
-                user_attribute,
-                self.store.efs(),
-            ),
-            Location::Volatile => self.read_dir_files_first_impl(
-                clients_dir,
-                location,
-                user_attribute,
-                self.store.vfs(),
-            ),
-        }
+        self.read_dir_files_first_impl(clients_dir, location, user_attribute)
     }
 
     fn read_dir_files_next(
         &mut self,
         state: ReadDirFilesState,
     ) -> Result<Option<(Option<Message>, ReadDirFilesState)>> {
-        match state.location {
-            Location::Internal => self.read_dir_files_next_impl(state, self.store.ifs()),
-            Location::External => self.read_dir_files_next_impl(state, self.store.efs()),
-            Location::Volatile => self.read_dir_files_next_impl(state, self.store.vfs()),
-        }
+        self.read_dir_files_next_impl(state)
     }
 
     fn locate_file(
@@ -497,16 +463,16 @@ impl<S: Store> Filestore for ClientFilestore<S> {
 
         let clients_dir = underneath.unwrap_or_else(|| path!("/"));
         let dir = self.actual_path(clients_dir)?;
-        let fs = self.store.ifs();
+        let fs = self.store.fs(Location::Internal);
 
         info_now!("base dir {:?}", &dir);
 
-        fn recursively_locate<S: 'static + crate::types::LfsStorage>(
-            fs: &'static crate::store::Fs<S>,
+        fn recursively_locate(
+            fs: &dyn DynFilesystem,
             dir: &Path,
             filename: &Path,
         ) -> Option<PathBuf> {
-            fs.read_dir_and_then(dir, |it| {
+            fs.read_dir_and_then(dir, &mut |it| {
                 it.map(|entry| entry.unwrap())
                     .skip(2)
                     .filter_map(|entry| {

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use generic_array::typenum::{U512, U8};
-use littlefs2::{const_ram_storage, driver::Storage, fs::Allocation};
+use littlefs2::{const_ram_storage, driver::Storage, fs::Allocation, object_safe::DynStorage};
 
 use crate::{
     store,
@@ -17,7 +17,7 @@ use crate::{
 pub trait StoreProvider {
     type Store: Store;
 
-    unsafe fn ifs() -> &'static mut <Self::Store as Store>::I;
+    unsafe fn ifs() -> &'static mut dyn DynStorage;
 
     unsafe fn store() -> Self::Store;
 
@@ -132,7 +132,7 @@ impl Filesystem {
 impl StoreProvider for Filesystem {
     type Store = FilesystemStore;
 
-    unsafe fn ifs() -> &'static mut FilesystemStorage {
+    unsafe fn ifs() -> &'static mut dyn DynStorage {
         INTERNAL_FILESYSTEM_STORAGE
             .as_mut()
             .expect("ifs not initialized")
@@ -175,7 +175,7 @@ pub struct Ram {}
 impl StoreProvider for Ram {
     type Store = RamStore;
 
-    unsafe fn ifs() -> &'static mut InternalStorage {
+    unsafe fn ifs() -> &'static mut dyn DynStorage {
         INTERNAL_RAM_STORAGE.as_mut().expect("ifs not initialized")
     }
 


### PR DESCRIPTION
Depends on:
- https://github.com/trussed-dev/trussed/pull/144

Alternatively, we could completely drop the `Store` trait and just use a struct with three references.  To be tested whether that is more efficient.