### PR TITLE
Add nonce to wrap_key and unwrap_key syscalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by default).
 - Change store implementations to use littlefs2’s `DynFilesystem` trait instead
   of being generic over the storage implementation.
+- Add `nonce` argument to `wrap_key` and `unwrap_key` syscalls.
 
 ### Fixed
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -312,6 +312,7 @@ pub mod request {
           - wrapping_key: KeyId
           - wrapped_key: Message
           - associated_data: Message
+          - nonce: ShortData
           - attributes: StorageAttributes
 
         Verify:
@@ -327,6 +328,7 @@ pub mod request {
           - wrapping_key: KeyId
           - key: KeyId
           - associated_data: ShortData
+          - nonce: Option<ShortData>
 
         RequestUserConsent:
           - level: consent::Level

--- a/src/client.rs
+++ b/src/client.rs
@@ -537,15 +537,18 @@ pub trait CryptoClient: PollClient {
         wrapping_key: KeyId,
         wrapped_key: Message,
         associated_data: &[u8],
+        nonce: &[u8],
         attributes: StorageAttributes,
     ) -> ClientResult<'c, reply::UnwrapKey, Self> {
         let associated_data =
             Message::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
+        let nonce = ShortData::from_slice(nonce).map_err(|_| ClientError::DataTooLarge)?;
         self.request(request::UnwrapKey {
             mechanism,
             wrapping_key,
             wrapped_key,
             associated_data,
+            nonce,
             attributes,
         })
     }
@@ -556,6 +559,7 @@ pub trait CryptoClient: PollClient {
         wrapping_key: KeyId,
         key: KeyId,
         associated_data: &[u8],
+        nonce: Option<ShortData>,
     ) -> ClientResult<'_, reply::WrapKey, Self> {
         let associated_data =
             Bytes::from_slice(associated_data).map_err(|_| ClientError::DataTooLarge)?;
@@ -564,6 +568,7 @@ pub trait CryptoClient: PollClient {
             wrapping_key,
             key,
             associated_data,
+            nonce,
         })
     }
 }

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -17,7 +17,7 @@ pub trait Aes256Cbc: CryptoClient {
         wrapping_key: KeyId,
         key: KeyId,
     ) -> ClientResult<'_, reply::WrapKey, Self> {
-        self.wrap_key(Mechanism::Aes256Cbc, wrapping_key, key, &[])
+        self.wrap_key(Mechanism::Aes256Cbc, wrapping_key, key, &[], None)
     }
 }
 
@@ -81,6 +81,7 @@ pub trait Chacha8Poly1305: CryptoClient {
             wrapping_key,
             Message::from_slice(wrapped_key).map_err(|_| ClientError::DataTooLarge)?,
             associated_data,
+            &[],
             StorageAttributes::new().set_persistence(location),
         )
     }
@@ -90,12 +91,14 @@ pub trait Chacha8Poly1305: CryptoClient {
         wrapping_key: KeyId,
         key: KeyId,
         associated_data: &[u8],
+        nonce: Option<&[u8; 12]>,
     ) -> ClientResult<'c, reply::WrapKey, Self> {
         self.wrap_key(
             Mechanism::Chacha8Poly1305,
             wrapping_key,
             key,
             associated_data,
+            nonce.and_then(|nonce| ShortData::from_slice(nonce).ok()),
         )
     }
 }

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -83,7 +83,7 @@ impl WrapKey for super::Aes256Cbc {
             key: request.wrapping_key,
             message,
             associated_data: request.associated_data.clone(),
-            nonce: None,
+            nonce: request.nonce.clone(),
         };
         let encryption_reply = <super::Aes256Cbc>::encrypt(keystore, &encryption_request)?;
 

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -183,7 +183,7 @@ impl WrapKey for super::Chacha8Poly1305 {
             key: request.wrapping_key,
             message,
             associated_data: request.associated_data.clone(),
-            nonce: None,
+            nonce: request.nonce.clone(),
         };
         let encryption_reply = <super::Chacha8Poly1305>::encrypt(keystore, &encryption_request)?;
 


### PR DESCRIPTION
This patch adds a nonce argument to the wrap_key and unwrap_key syscalls to be able to use the Aes256Cbc mechanism with a non-zero IV in the future.

----

I’m not sure if it really makes sense to add the nonce to `unwrap_key` too.  For Aes256Cbc it would be useful, but it currently does not implement `unwrap_key` anyway.  For ChaCha8Poly1305, the encryption result including the nonce is serialized so it does not need to be passed manually by the caller.