### PR TITLE
derive: Add options for ExtensionDispatch

### DIFF
--- a/derive/examples/extension-dispatch.rs
+++ b/derive/examples/extension-dispatch.rs
@@ -127,6 +127,10 @@ struct Dispatch {
     a_sample: (),
 
     b: backends::BBackend,
+
+    #[allow(unused)]
+    #[dispatch(skip)]
+    other: String,
 }
 
 fn main() {

--- a/derive/examples/extension-dispatch.rs
+++ b/derive/examples/extension-dispatch.rs
@@ -119,6 +119,7 @@ enum Extension {
     Sample = "extensions::SampleExtension"
 )]
 struct Dispatch {
+    #[dispatch(no_core)]
     #[extensions("Test")]
     a: backends::ABackend,
 


### PR DESCRIPTION
This patch adds more options to the ExtensionDispatch derive macro so that it can be used for nitrokey-3-firmware:
- `delegate_to` makes it possible to create an alias for a backend using a different set of extensions.  To avoid misunderstandings, delegating backends are forced to use the unit type ().
- `skip` ignores fields.
- `no_core` skips backends when dispatching core requests.