### PR TITLE
Fix pipeline

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+#![allow(static_mut_refs)]
 use chacha20::ChaCha20;
 
 use crate::types::*;


### PR DESCRIPTION
We will want to get rid of the static mut altogether, But that will be done when moving to Rust 2024. For now just fix the CI