### PR TITLE
Reorganize imports

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -366,7 +366,7 @@ pub mod request {
         Uptime:
 
         Wink:
-          - duration: core::time::Duration
+          - duration: Duration
 
         SetCustomStatus:
           - status: u8

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,11 @@
 //! [pkcs11-v3]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html
 //! [pkcs11-headers]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/cs01/include/pkcs11-v3.0/
 
-use crate::types::*;
+use crate::types::{
+    consent, reboot, Bytes, CertId, CounterId, DirEntry, KeyId, KeySerialization, Location,
+    Mechanism, MediumData, Message, PathBuf, SerializedKey, ShortData, Signature,
+    SignatureSerialization, StorageAttributes, UserAttribute,
+};
 use core::time::Duration;
 
 #[macro_use]

--- a/src/client.rs
+++ b/src/client.rs
@@ -77,13 +77,17 @@
 //!
 use core::{marker::PhantomData, task::Poll};
 
-use crate::api::*;
+use crate::api::{reply, request, NotBefore, Reply, ReplyVariant, RequestVariant};
 use crate::backend::{BackendId, CoreOnly, Dispatch};
-use crate::error::*;
+use crate::error::{Error, Result};
 use crate::interrupt::InterruptFlag;
 use crate::pipe::{TrussedRequester, TRUSSED_INTERCHANGE};
 use crate::service::Service;
-use crate::types::*;
+use crate::types::{
+    consent, reboot, Bytes, CertId, CounterId, KeyId, KeySerialization, Location, Mechanism,
+    MediumData, Message, PathBuf, Platform, SerializedKey, ShortData, Signature,
+    SignatureSerialization, StorageAttributes, UserAttribute,
+};
 
 pub use crate::platform::Syscall;
 

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,4 +1,10 @@
-use super::*;
+use super::{ClientError, ClientImplementation, ClientResult, CryptoClient};
+use crate::api::reply;
+use crate::platform::Syscall;
+use crate::types::{
+    KeyId, KeySerialization, Location, Mechanism, MediumData, Message, ShortData,
+    SignatureSerialization, StorageAttributes,
+};
 
 #[cfg(feature = "aes256-cbc")]
 impl<S: Syscall, E> Aes256Cbc for ClientImplementation<S, E> {}

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -1,8 +1,9 @@
-use crate::api::*;
-// use crate::config::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{Decrypt, Encrypt, UnsafeInjectKey, WrapKey};
+use crate::store::keystore::Keystore;
+use crate::types::{Mechanism, Message, ShortData};
 
 const AES256_KEY_SIZE: usize = 32;
 

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -1,9 +1,12 @@
-use crate::api::*;
-// use crate::config::*;
+use generic_array::GenericArray;
+use rand_core::RngCore;
+
+use crate::api::{reply, request};
 use crate::error::Error;
 use crate::key;
-use crate::service::*;
-use crate::types::*;
+use crate::service::{Decrypt, Encrypt, GenerateKey, UnwrapKey, WrapKey};
+use crate::store::keystore::Keystore;
+use crate::types::{Mechanism, Message, ShortData};
 
 // TODO: The non-detached versions seem better.
 // This needs a bit of additional type gymnastics.

--- a/src/mechanisms/ed255.rs
+++ b/src/mechanisms/ed255.rs
@@ -1,11 +1,15 @@
-use core::convert::{TryFrom, TryInto};
+use rand_core::RngCore;
 
-use crate::api::*;
-// use crate::config::*;
-// use crate::debug;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{
+    DeriveKey, DeserializeKey, Exists, GenerateKey, SerializeKey, Sign, UnsafeInjectKey, Verify,
+};
+use crate::store::keystore::Keystore;
+use crate::types::{
+    Bytes, KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization,
+};
 
 #[inline(never)]
 fn load_public_key(

--- a/src/mechanisms/hmacblake2s.rs
+++ b/src/mechanisms/hmacblake2s.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-blake2s")]
 impl DeriveKey for super::HmacBlake2s {

--- a/src/mechanisms/hmacsha1.rs
+++ b/src/mechanisms/hmacsha1.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-sha1")]
 impl DeriveKey for super::HmacSha1 {

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-sha256")]
 impl DeriveKey for super::HmacSha256 {

--- a/src/mechanisms/hmacsha512.rs
+++ b/src/mechanisms/hmacsha512.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-sha512")]
 impl DeriveKey for super::HmacSha512 {

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -1,9 +1,14 @@
-// use core::convert::{TryFrom, TryInto};
-
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{
+    Agree, DeriveKey, DeserializeKey, Exists, GenerateKey, SerializeKey, Sign, UnsafeInjectKey,
+    Verify,
+};
+use crate::store::keystore::Keystore;
+use crate::types::{
+    Bytes, KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization,
+};
 
 #[inline(never)]
 fn load_secret_key(

--- a/src/mechanisms/sha256.rs
+++ b/src/mechanisms/sha256.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Hash};
+use crate::store::keystore::Keystore;
+use crate::types::ShortData;
 
 #[cfg(feature = "sha256")]
 impl DeriveKey for super::Sha256 {

--- a/src/mechanisms/shared_secret.rs
+++ b/src/mechanisms/shared_secret.rs
@@ -1,8 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
 use crate::key;
-use crate::service::*;
-use crate::types::*;
+use crate::service::{SerializeKey, UnsafeInjectKey};
+use crate::store::keystore::Keystore;
+use crate::types::{KeySerialization, SerializedKey};
 
 impl SerializeKey for super::SharedSecret {
     #[inline(never)]

--- a/src/mechanisms/tdes.rs
+++ b/src/mechanisms/tdes.rs
@@ -8,11 +8,13 @@
 // needed to even get ::new() from des...
 #[cfg(feature = "tdes")]
 use des::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use generic_array::GenericArray;
 
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{Decrypt, Encrypt, UnsafeInjectKey};
+use crate::store::keystore::Keystore;
 
 const TDES_KEY_SIZE: usize = 24;
 

--- a/src/mechanisms/totp.rs
+++ b/src/mechanisms/totp.rs
@@ -1,6 +1,8 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
+use crate::key;
+use crate::service::{Exists, Sign};
+use crate::store::keystore::Keystore;
 
 // code copied from https://github.com/avacariu/rust-oath
 

--- a/src/mechanisms/trng.rs
+++ b/src/mechanisms/trng.rs
@@ -1,6 +1,10 @@
-use crate::api::*;
+use rand_core::RngCore;
+
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
+use crate::key;
+use crate::service::GenerateKey;
+use crate::store::keystore::Keystore;
 
 #[cfg(feature = "trng")]
 impl GenerateKey for super::Trng {

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -1,13 +1,14 @@
-use core::convert::TryInto;
-
-use crate::api::*;
-// use crate::config::*;
-// use crate::debug;
-use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
-
+use rand_core::RngCore;
 use salty::agreement;
+
+use crate::api::{reply, request};
+use crate::error::Error;
+use crate::key;
+use crate::service::{
+    Agree, DeriveKey, DeserializeKey, Exists, GenerateKey, SerializeKey, UnsafeInjectKey,
+};
+use crate::store::keystore::Keystore;
+use crate::types::{KeyId, KeySerialization, SerializedKey};
 
 fn load_public_key(
     keystore: &mut impl Keystore,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,5 @@
 use littlefs2::{
+    object_safe::DynFilesystem,
     path,
     path::{Path, PathBuf},
 };
@@ -7,25 +8,27 @@ pub use rand_core::{RngCore, SeedableRng};
 
 use crate::backend::{BackendId, CoreOnly, Dispatch};
 use crate::client::{ClientBuilder, ClientImplementation};
-use crate::config::*;
+use crate::config::{MAX_MESSAGE_LENGTH, MAX_SERVICE_CLIENTS};
 use crate::error::{Error, Result};
 pub use crate::key;
 use crate::mechanisms;
 pub use crate::pipe::ServiceEndpoint;
 use crate::pipe::TrussedResponder;
-use crate::platform::*;
+use crate::platform::{consent, ui, Platform, Store, Syscall, UserInterface};
 pub use crate::store::{
     self,
     certstore::{Certstore as _, ClientCertstore},
     counterstore::{ClientCounterstore, Counterstore as _},
     filestore::{ClientFilestore, Filestore, ReadDirFilesState, ReadDirState},
     keystore::{ClientKeystore, Keystore},
-    DynFilesystem,
 };
 use crate::types::ui::Status;
-use crate::types::*;
+use crate::types::{Context, CoreContext, Location, Mechanism, MediumData, Message, Vec};
 use crate::Bytes;
-use crate::{api::*, interrupt::InterruptFlag};
+use crate::{
+    api::{reply, request, Reply, Request},
+    interrupt::InterruptFlag,
+};
 
 pub mod attest;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -954,7 +954,7 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
     }
 }
 
-impl<P, D> crate::client::Syscall for &mut Service<P, D>
+impl<P, D> Syscall for &mut Service<P, D>
 where
     P: Platform,
     D: Dispatch,
@@ -964,7 +964,7 @@ where
     }
 }
 
-impl<P, D> crate::client::Syscall for Service<P, D>
+impl<P, D> Syscall for Service<P, D>
 where
     P: Platform,
     D: Dispatch,

--- a/src/store.rs
+++ b/src/store.rs
@@ -71,8 +71,10 @@
 //! - Alternative: subdirectory <==> RP hash, everything else in flat files
 //! - In any case need to "list dirs excluding . and .." or similar
 
+use littlefs2::{driver::Storage, fs::Filesystem};
+
 use crate::error::Error;
-use crate::types::*;
+use crate::types::{Bytes, Location, PathBuf};
 #[allow(unused_imports)]
 #[cfg(feature = "semihosting")]
 use cortex_m_semihosting::hprintln;
@@ -127,9 +129,9 @@ pub mod keystore;
 //
 // This makes everything using it *much* more ergonomic.
 pub unsafe trait Store: Copy {
-    type I: 'static + LfsStorage;
-    type E: 'static + LfsStorage;
-    type V: 'static + LfsStorage;
+    type I: 'static + Storage;
+    type E: 'static + Storage;
+    type V: 'static + Storage;
     fn ifs(self) -> &'static Fs<Self::I>;
     fn efs(self) -> &'static Fs<Self::E>;
     fn vfs(self) -> &'static Fs<Self::V>;
@@ -142,18 +144,18 @@ pub unsafe trait Store: Copy {
     }
 }
 
-pub struct Fs<S: 'static + LfsStorage> {
+pub struct Fs<S: 'static + Storage> {
     fs: &'static Filesystem<'static, S>,
 }
 
-impl<S: 'static + LfsStorage> core::ops::Deref for Fs<S> {
+impl<S: 'static + Storage> core::ops::Deref for Fs<S> {
     type Target = Filesystem<'static, S>;
     fn deref(&self) -> &Self::Target {
         self.fs
     }
 }
 
-impl<S: 'static + LfsStorage> Fs<S> {
+impl<S: 'static + Storage> Fs<S> {
     pub fn new(fs: &'static Filesystem<'static, S>) -> Self {
         Self { fs }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 #![allow(static_mut_refs)]
+
 use chacha20::ChaCha20;
 
 use crate::types::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -447,8 +447,8 @@ impl TryFrom<ShortData> for Letters {
     }
 }
 
-impl serde::Serialize for Id {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+impl Serialize for Id {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -456,8 +456,8 @@ impl serde::Serialize for Id {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Id {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+impl<'de> Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -470,7 +470,7 @@ impl<'de> serde::Deserialize<'de> for Id {
                 formatter.write_str("16 bytes")
             }
 
-            fn visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E>
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,7 +194,7 @@ impl KeyId {
 // impl_id!(SecretKeyId);
 
 pub mod ui {
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
     // TODO: Consider whether a simple "language" to specify "patterns"
     // makes sense, vs. "semantic" indications with platform-specific implementation
@@ -210,7 +210,7 @@ pub mod ui {
 }
 
 pub mod reboot {
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
     pub enum To {
@@ -220,7 +220,7 @@ pub mod reboot {
 }
 
 pub mod consent {
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
     pub enum Level {

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -6,13 +6,12 @@ use std::{
 };
 
 use generic_array::typenum::{U512, U8};
-use littlefs2::{const_ram_storage, driver::Storage, fs::Allocation};
-
-use crate::{
-    store,
-    store::Store,
-    types::{LfsResult, LfsStorage},
+use littlefs2::{
+    const_ram_storage, driver::Storage, driver::Storage as LfsStorage, fs::Allocation,
+    io::Result as LfsResult,
 };
+
+use crate::{store, store::Store};
 
 pub trait StoreProvider {
     type Store: Store;

--- a/tests/store/mod.rs
+++ b/tests/store/mod.rs
@@ -1,5 +1,6 @@
 use littlefs2::const_ram_storage;
-use trussed::types::{LfsResult, LfsStorage};
+use littlefs2::driver::Storage as LfsStorage;
+use littlefs2::io::Result as LfsResult;
 
 const_ram_storage!(InternalStorage, 8192);
 // const_ram_storage!(InternalStorage, 16384);


### PR DESCRIPTION
This patch removes some unnecessary qualifications, directly uses external dependencies instead of re-exports and removes some wildcard imports.  The goal is to make the dependencies between modules clearer and refactoring easier.

This is a purely internal change that does not affect the public API.