### PR TITLE
Reduce re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use nonce as IV for Aes256Cbc mechanism.
 - Reduce re-exports ([#155][]):
   - Remove most re-exports of external types
+  - Remove all re-exports of internal types
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of being generic over the storage implementation.
 - Add `nonce` argument to `wrap_key` and `unwrap_key` syscalls.
 - Use nonce as IV for Aes256Cbc mechanism.
+- Reduce re-exports ([#155][]):
+  - Remove most re-exports of external types
 
 ### Fixed
 
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#64]: https://github.com/trussed-dev/trussed/issues/64
 [#65]: https://github.com/trussed-dev/trussed/issues/65
 [#99]: https://github.com/trussed-dev/trussed/issues/99
+[#155]: https://github.com/trussed-dev/trussed/issues/155
 
 ## [0.1.0] - 2022-01-26
 

--- a/derive/src/extension_id.rs
+++ b/derive/src/extension_id.rs
@@ -44,12 +44,12 @@ impl ExtensionId {
             }
 
             impl #impl_generics ::core::convert::TryFrom<u8> for #name #ty_generics #where_clause {
-                type Error = ::trussed::Error;
+                type Error = ::trussed::error::Error;
 
                 fn try_from(value: u8) -> ::core::result::Result<Self, Self::Error> {
                     match value {
                         #(#try_from)*
-                        _ => Err(::trussed::Error::InternalError),
+                        _ => Err(::trussed::error::Error::InternalError),
                     }
                 }
             }

--- a/src/api.rs
+++ b/src/api.rs
@@ -366,7 +366,7 @@ pub mod request {
         Uptime:
 
         Wink:
-          - duration: core::time::Duration
+          - duration: Duration
 
         SetCustomStatus:
           - status: u8

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,11 @@
 //! [pkcs11-v3]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html
 //! [pkcs11-headers]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/cs01/include/pkcs11-v3.0/
 
-use crate::types::*;
+use crate::types::{
+    consent, reboot, Bytes, CertId, CounterId, DirEntry, KeyId, KeySerialization, Location,
+    Mechanism, MediumData, Message, PathBuf, SerializedKey, ShortData, Signature,
+    SignatureSerialization, StorageAttributes, UserAttribute,
+};
 use core::time::Duration;
 
 #[macro_use]

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,6 +5,7 @@
 //! [pkcs11-v3]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html
 //! [pkcs11-headers]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/cs01/include/pkcs11-v3.0/
 
+use crate::error::Error;
 use crate::types::{
     consent, reboot, Bytes, CertId, CounterId, DirEntry, KeyId, KeySerialization, Location,
     Mechanism, MediumData, Message, PathBuf, SerializedKey, ShortData, Signature,
@@ -143,11 +144,11 @@ generate_enums! {
     SerdeExtension: 0x5E
 }
 
-pub trait RequestVariant: Into<Request> + TryFrom<Request, Error = crate::Error> {
+pub trait RequestVariant: Into<Request> + TryFrom<Request, Error = Error> {
     type Reply: ReplyVariant<Request = Self>;
 }
 
-pub trait ReplyVariant: Into<Reply> + TryFrom<Reply, Error = crate::Error> {
+pub trait ReplyVariant: Into<Reply> + TryFrom<Reply, Error = Error> {
     type Request: RequestVariant<Reply = Self>;
 }
 

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -84,11 +84,11 @@ macro_rules! impl_request {
         }
     }
     impl core::convert::TryFrom<Request> for $request {
-        type Error = crate::Error;
+        type Error = crate::error::Error;
         fn try_from(request: Request) -> Result<request::$request, Self::Error> {
             match request {
                 Request::$request(request) => Ok(request),
-                _ => Err(crate::Error::InternalError),
+                _ => Err(crate::error::Error::InternalError),
             }
         }
     }
@@ -118,11 +118,11 @@ macro_rules! impl_reply {
 
     $(#[$attr])?
     impl core::convert::TryFrom<Reply> for $reply {
-        type Error = crate::Error;
+        type Error = crate::error::Error;
         fn try_from(reply: Reply) -> Result<reply::$reply, Self::Error> {
             match reply {
                 Reply::$reply(reply) => Ok(reply),
-                _ => Err(crate::Error::InternalError),
+                _ => Err(crate::error::Error::InternalError),
             }
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -77,13 +77,17 @@
 //!
 use core::{marker::PhantomData, task::Poll};
 
-use crate::api::*;
+use crate::api::{reply, request, NotBefore, Reply, ReplyVariant, RequestVariant};
 use crate::backend::{BackendId, CoreOnly, Dispatch};
-use crate::error::*;
+use crate::error::{Error, Result};
 use crate::interrupt::InterruptFlag;
 use crate::pipe::{TrussedRequester, TRUSSED_INTERCHANGE};
 use crate::service::Service;
-use crate::types::*;
+use crate::types::{
+    consent, reboot, Bytes, CertId, CounterId, KeyId, KeySerialization, Location, Mechanism,
+    MediumData, Message, PathBuf, Platform, SerializedKey, ShortData, Signature,
+    SignatureSerialization, StorageAttributes, UserAttribute,
+};
 
 pub use crate::platform::Syscall;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -82,17 +82,15 @@ use crate::backend::{BackendId, CoreOnly, Dispatch};
 use crate::error::{Error, Result};
 use crate::interrupt::InterruptFlag;
 use crate::pipe::{TrussedRequester, TRUSSED_INTERCHANGE};
+use crate::platform::{Platform, Syscall};
 use crate::service::Service;
 use crate::types::{
     consent, reboot, Bytes, CertId, CounterId, KeyId, KeySerialization, Location, Mechanism,
-    MediumData, Message, PathBuf, Platform, SerializedKey, ShortData, Signature,
-    SignatureSerialization, StorageAttributes, UserAttribute,
+    MediumData, Message, PathBuf, SerializedKey, ShortData, Signature, SignatureSerialization,
+    StorageAttributes, UserAttribute,
 };
 
-pub use crate::platform::Syscall;
-
 pub mod mechanisms;
-pub use mechanisms::*;
 
 // to be fair, this is a programmer error,
 // and could also just panic

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,4 +1,10 @@
-use super::*;
+use super::{ClientError, ClientImplementation, ClientResult, CryptoClient};
+use crate::api::reply;
+use crate::platform::Syscall;
+use crate::types::{
+    KeyId, KeySerialization, Location, Mechanism, MediumData, Message, ShortData,
+    SignatureSerialization, StorageAttributes,
+};
 
 #[cfg(feature = "aes256-cbc")]
 impl<S: Syscall, E> Aes256Cbc for ClientImplementation<S, E> {}

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,7 +7,7 @@ use zeroize::Zeroize;
 
 use crate::{
     config::{MAX_KEY_MATERIAL_LENGTH, MAX_SERIALIZED_KEY_LENGTH},
-    Error,
+    error::Error,
 };
 
 pub type Material = Vec<u8, { MAX_KEY_MATERIAL_LENGTH }>;

--- a/src/key.rs
+++ b/src/key.rs
@@ -5,7 +5,6 @@ use heapless::Vec;
 use serde::{de::Visitor, ser::SerializeMap, Deserialize, Serialize};
 use zeroize::Zeroize;
 
-pub use crate::Bytes;
 use crate::{
     config::{MAX_KEY_MATERIAL_LENGTH, MAX_SERIALIZED_KEY_LENGTH},
     Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,13 +40,6 @@ pub mod types;
 #[cfg_attr(docsrs, doc(cfg(feature = "virt")))]
 pub mod virt;
 
-pub use api::Reply;
-pub use client::{Client, ClientImplementation};
-pub use error::Error;
-/// The trait that platforms need to implement to use Trussed.
-pub use platform::Platform;
-pub use service::Service;
-
 pub use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
 
 pub(crate) use postcard::from_bytes as postcard_deserialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@
 extern crate delog;
 generate_macros!();
 
-pub use interchange::Interchange;
-
 pub mod api;
 pub mod backend;
 pub mod client;
@@ -50,15 +48,14 @@ pub use platform::Platform;
 pub use service::Service;
 
 pub use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
-pub use heapless_bytes::Bytes;
 
 pub(crate) use postcard::from_bytes as postcard_deserialize;
 
 pub(crate) fn postcard_serialize_bytes<T: serde::Serialize, const N: usize>(
     object: &T,
-) -> postcard::Result<Bytes<N>> {
+) -> postcard::Result<types::Bytes<N>> {
     let vec = postcard::to_vec(object)?;
-    Ok(Bytes::from(vec))
+    Ok(types::Bytes::from(vec))
 }
 
 #[cfg(test)]

--- a/src/mechanisms/aes256cbc.rs
+++ b/src/mechanisms/aes256cbc.rs
@@ -1,8 +1,9 @@
-use crate::api::*;
-// use crate::config::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{Decrypt, Encrypt, UnsafeInjectKey, WrapKey};
+use crate::store::keystore::Keystore;
+use crate::types::{Mechanism, Message, ShortData};
 
 const AES256_KEY_SIZE: usize = 32;
 

--- a/src/mechanisms/chacha8poly1305.rs
+++ b/src/mechanisms/chacha8poly1305.rs
@@ -1,9 +1,12 @@
-use crate::api::*;
-// use crate::config::*;
+use generic_array::GenericArray;
+use rand_core::RngCore;
+
+use crate::api::{reply, request};
 use crate::error::Error;
 use crate::key;
-use crate::service::*;
-use crate::types::*;
+use crate::service::{Decrypt, Encrypt, GenerateKey, UnwrapKey, WrapKey};
+use crate::store::keystore::Keystore;
+use crate::types::{Mechanism, Message, ShortData};
 
 // TODO: The non-detached versions seem better.
 // This needs a bit of additional type gymnastics.

--- a/src/mechanisms/ed255.rs
+++ b/src/mechanisms/ed255.rs
@@ -1,11 +1,15 @@
-use core::convert::{TryFrom, TryInto};
+use rand_core::RngCore;
 
-use crate::api::*;
-// use crate::config::*;
-// use crate::debug;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{
+    DeriveKey, DeserializeKey, Exists, GenerateKey, SerializeKey, Sign, UnsafeInjectKey, Verify,
+};
+use crate::store::keystore::Keystore;
+use crate::types::{
+    Bytes, KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization,
+};
 
 #[inline(never)]
 fn load_public_key(

--- a/src/mechanisms/hmacblake2s.rs
+++ b/src/mechanisms/hmacblake2s.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-blake2s")]
 impl DeriveKey for super::HmacBlake2s {

--- a/src/mechanisms/hmacsha1.rs
+++ b/src/mechanisms/hmacsha1.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-sha1")]
 impl DeriveKey for super::HmacSha1 {

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-sha256")]
 impl DeriveKey for super::HmacSha256 {

--- a/src/mechanisms/hmacsha512.rs
+++ b/src/mechanisms/hmacsha512.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Sign};
+use crate::store::keystore::Keystore;
+use crate::types::Signature;
 
 #[cfg(feature = "hmac-sha512")]
 impl DeriveKey for super::HmacSha512 {

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -1,9 +1,14 @@
-// use core::convert::{TryFrom, TryInto};
-
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{
+    Agree, DeriveKey, DeserializeKey, Exists, GenerateKey, SerializeKey, Sign, UnsafeInjectKey,
+    Verify,
+};
+use crate::store::keystore::Keystore;
+use crate::types::{
+    Bytes, KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization,
+};
 
 #[inline(never)]
 fn load_secret_key(

--- a/src/mechanisms/sha256.rs
+++ b/src/mechanisms/sha256.rs
@@ -1,7 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{DeriveKey, Hash};
+use crate::store::keystore::Keystore;
+use crate::types::ShortData;
 
 #[cfg(feature = "sha256")]
 impl DeriveKey for super::Sha256 {

--- a/src/mechanisms/shared_secret.rs
+++ b/src/mechanisms/shared_secret.rs
@@ -1,8 +1,9 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
 use crate::key;
-use crate::service::*;
-use crate::types::*;
+use crate::service::{SerializeKey, UnsafeInjectKey};
+use crate::store::keystore::Keystore;
+use crate::types::{KeySerialization, SerializedKey};
 
 impl SerializeKey for super::SharedSecret {
     #[inline(never)]

--- a/src/mechanisms/tdes.rs
+++ b/src/mechanisms/tdes.rs
@@ -8,11 +8,13 @@
 // needed to even get ::new() from des...
 #[cfg(feature = "tdes")]
 use des::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use generic_array::GenericArray;
 
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
+use crate::key;
+use crate::service::{Decrypt, Encrypt, UnsafeInjectKey};
+use crate::store::keystore::Keystore;
 
 const TDES_KEY_SIZE: usize = 24;
 

--- a/src/mechanisms/totp.rs
+++ b/src/mechanisms/totp.rs
@@ -3,6 +3,7 @@ use crate::error::Error;
 use crate::key;
 use crate::service::{Exists, Sign};
 use crate::store::keystore::Keystore;
+use crate::types::Bytes;
 
 // code copied from https://github.com/avacariu/rust-oath
 
@@ -72,7 +73,7 @@ impl Sign for super::Totp {
 
         // return signature (encode as LE)
         Ok(reply::Sign {
-            signature: crate::Bytes::from_slice(totp_material.to_le_bytes().as_ref()).unwrap(),
+            signature: Bytes::from_slice(totp_material.to_le_bytes().as_ref()).unwrap(),
         })
     }
 }

--- a/src/mechanisms/totp.rs
+++ b/src/mechanisms/totp.rs
@@ -1,6 +1,8 @@
-use crate::api::*;
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
+use crate::key;
+use crate::service::{Exists, Sign};
+use crate::store::keystore::Keystore;
 
 // code copied from https://github.com/avacariu/rust-oath
 

--- a/src/mechanisms/trng.rs
+++ b/src/mechanisms/trng.rs
@@ -1,6 +1,10 @@
-use crate::api::*;
+use rand_core::RngCore;
+
+use crate::api::{reply, request};
 use crate::error::Error;
-use crate::service::*;
+use crate::key;
+use crate::service::GenerateKey;
+use crate::store::keystore::Keystore;
 
 #[cfg(feature = "trng")]
 impl GenerateKey for super::Trng {

--- a/src/mechanisms/x255.rs
+++ b/src/mechanisms/x255.rs
@@ -1,13 +1,14 @@
-use core::convert::TryInto;
-
-use crate::api::*;
-// use crate::config::*;
-// use crate::debug;
-use crate::error::Error;
-use crate::service::*;
-use crate::types::*;
-
+use rand_core::RngCore;
 use salty::agreement;
+
+use crate::api::{reply, request};
+use crate::error::Error;
+use crate::key;
+use crate::service::{
+    Agree, DeriveKey, DeserializeKey, Exists, GenerateKey, SerializeKey, UnsafeInjectKey,
+};
+use crate::store::keystore::Keystore;
+use crate::types::{KeyId, KeySerialization, SerializedKey};
 
 fn load_public_key(
     keystore: &mut impl Keystore,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -6,11 +6,11 @@
 //!
 //! TODO: Currently, `Platform::R` lacks the `CryptoRng` bound.
 
-// pub use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
+
 pub use crate::store::Store;
 pub use crate::types::consent;
 pub use crate::types::{reboot, ui};
-pub use rand_core::{CryptoRng, RngCore};
 
 pub trait UserInterface {
     /// Check if the user has indicated their presence so as to give

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -8,9 +8,8 @@
 
 use rand_core::{CryptoRng, RngCore};
 
-pub use crate::store::Store;
-pub use crate::types::consent;
-pub use crate::types::{reboot, ui};
+use crate::store::Store;
+use crate::types::{consent, reboot, ui};
 
 pub trait UserInterface {
     /// Check if the user has indicated their presence so as to give

--- a/src/service.rs
+++ b/src/service.rs
@@ -11,19 +11,22 @@ use crate::backend::{BackendId, CoreOnly, Dispatch};
 use crate::client::{ClientBuilder, ClientImplementation};
 use crate::config::{MAX_MESSAGE_LENGTH, MAX_SERVICE_CLIENTS};
 use crate::error::{Error, Result};
-pub use crate::key;
+use crate::key;
 use crate::mechanisms;
-pub use crate::pipe::ServiceEndpoint;
+use crate::pipe::ServiceEndpoint;
 use crate::pipe::TrussedResponder;
-use crate::platform::{consent, ui, Platform, Store, Syscall, UserInterface};
-pub use crate::store::{
-    self,
+use crate::platform::{Platform, Syscall, UserInterface};
+use crate::store::{
     certstore::{Certstore as _, ClientCertstore},
     counterstore::{ClientCounterstore, Counterstore as _},
-    filestore::{ClientFilestore, Filestore, ReadDirFilesState, ReadDirState},
+    filestore::{ClientFilestore, Filestore},
     keystore::{ClientKeystore, Keystore},
+    Store,
 };
-use crate::types::ui::Status;
+use crate::types::{
+    consent,
+    ui::{self, Status},
+};
 use crate::types::{Bytes, Context, CoreContext, Location, Mechanism, MediumData, Message};
 use crate::{
     api::{reply, request, Reply, Request},

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,10 +1,11 @@
+use heapless::Vec;
 use littlefs2::{
     object_safe::DynFilesystem,
     path,
     path::{Path, PathBuf},
 };
 use rand_chacha::ChaCha8Rng;
-pub use rand_core::{RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 
 use crate::backend::{BackendId, CoreOnly, Dispatch};
 use crate::client::{ClientBuilder, ClientImplementation};
@@ -23,8 +24,7 @@ pub use crate::store::{
     keystore::{ClientKeystore, Keystore},
 };
 use crate::types::ui::Status;
-use crate::types::{Context, CoreContext, Location, Mechanism, MediumData, Message, Vec};
-use crate::Bytes;
+use crate::types::{Bytes, Context, CoreContext, Location, Mechanism, MediumData, Message};
 use crate::{
     api::{reply, request, Reply, Request},
     interrupt::InterruptFlag,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,5 @@
 use littlefs2::{
+    object_safe::DynFilesystem,
     path,
     path::{Path, PathBuf},
 };
@@ -7,25 +8,27 @@ pub use rand_core::{RngCore, SeedableRng};
 
 use crate::backend::{BackendId, CoreOnly, Dispatch};
 use crate::client::{ClientBuilder, ClientImplementation};
-use crate::config::*;
+use crate::config::{MAX_MESSAGE_LENGTH, MAX_SERVICE_CLIENTS};
 use crate::error::{Error, Result};
 pub use crate::key;
 use crate::mechanisms;
 pub use crate::pipe::ServiceEndpoint;
 use crate::pipe::TrussedResponder;
-use crate::platform::*;
+use crate::platform::{consent, ui, Platform, Store, Syscall, UserInterface};
 pub use crate::store::{
     self,
     certstore::{Certstore as _, ClientCertstore},
     counterstore::{ClientCounterstore, Counterstore as _},
     filestore::{ClientFilestore, Filestore, ReadDirFilesState, ReadDirState},
     keystore::{ClientKeystore, Keystore},
-    DynFilesystem,
 };
 use crate::types::ui::Status;
-use crate::types::*;
+use crate::types::{Context, CoreContext, Location, Mechanism, MediumData, Message, Vec};
 use crate::Bytes;
-use crate::{api::*, interrupt::InterruptFlag};
+use crate::{
+    api::{reply, request, Reply, Request},
+    interrupt::InterruptFlag,
+};
 
 pub mod attest;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -954,7 +954,7 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
     }
 }
 
-impl<P, D> crate::client::Syscall for &mut Service<P, D>
+impl<P, D> Syscall for &mut Service<P, D>
 where
     P: Platform,
     D: Dispatch,
@@ -964,7 +964,7 @@ where
     }
 }
 
-impl<P, D> crate::client::Syscall for Service<P, D>
+impl<P, D> Syscall for Service<P, D>
 where
     P: Platform,
     D: Dispatch,

--- a/src/store.rs
+++ b/src/store.rs
@@ -71,8 +71,10 @@
 //! - Alternative: subdirectory <==> RP hash, everything else in flat files
 //! - In any case need to "list dirs excluding . and .." or similar
 
+use littlefs2::{driver::Storage, fs::Filesystem};
+
 use crate::error::Error;
-use crate::types::*;
+use crate::types::{Bytes, Location, PathBuf};
 #[allow(unused_imports)]
 #[cfg(feature = "semihosting")]
 use cortex_m_semihosting::hprintln;
@@ -127,9 +129,9 @@ pub mod keystore;
 //
 // This makes everything using it *much* more ergonomic.
 pub unsafe trait Store: Copy {
-    type I: 'static + LfsStorage;
-    type E: 'static + LfsStorage;
-    type V: 'static + LfsStorage;
+    type I: 'static + Storage;
+    type E: 'static + Storage;
+    type V: 'static + Storage;
     fn ifs(self) -> &'static Fs<Self::I>;
     fn efs(self) -> &'static Fs<Self::E>;
     fn vfs(self) -> &'static Fs<Self::V>;
@@ -142,18 +144,18 @@ pub unsafe trait Store: Copy {
     }
 }
 
-pub struct Fs<S: 'static + LfsStorage> {
+pub struct Fs<S: 'static + Storage> {
     fs: &'static Filesystem<'static, S>,
 }
 
-impl<S: 'static + LfsStorage> core::ops::Deref for Fs<S> {
+impl<S: 'static + Storage> core::ops::Deref for Fs<S> {
     type Target = Filesystem<'static, S>;
     fn deref(&self) -> &Self::Target {
         self.fs
     }
 }
 
-impl<S: 'static + LfsStorage> Fs<S> {
+impl<S: 'static + Storage> Fs<S> {
     pub fn new(fs: &'static Filesystem<'static, S>) -> Self {
         Self { fs }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -80,10 +80,9 @@ use crate::types::{Bytes, Location, PathBuf};
 use cortex_m_semihosting::hprintln;
 use littlefs2::{
     fs::{DirEntry, Metadata},
+    object_safe::DynFilesystem,
     path::Path,
 };
-
-pub use littlefs2::object_safe::{DynFile, DynFilesystem, DynStorage};
 
 pub mod certstore;
 pub mod counterstore;

--- a/src/store/counterstore.rs
+++ b/src/store/counterstore.rs
@@ -4,7 +4,7 @@ use rand_chacha::ChaCha8Rng;
 use crate::{
     error::{Error, Result},
     store::{self, Store},
-    types::{CounterId, Location},
+    types::{Bytes, CounterId, Location},
 };
 
 pub struct ClientCounterstore<S>
@@ -37,7 +37,7 @@ impl<S: Store> ClientCounterstore<S> {
 
     fn read_counter(&mut self, location: Location, id: CounterId) -> Result<Counter> {
         let path = self.counter_path(id);
-        let mut bytes: crate::Bytes<16> = store::read(self.store, location, &path)?;
+        let mut bytes: Bytes<16> = store::read(self.store, location, &path)?;
         bytes.resize_default(16).ok();
         Ok(u128::from_le_bytes(bytes.as_slice().try_into().unwrap()))
     }

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -5,8 +5,7 @@ use crate::{
     error::{Error, Result},
     // service::ReadDirState,
     store::{self, DynFilesystem, Store},
-    types::{Location, Message, UserAttribute},
-    Bytes,
+    types::{Bytes, Location, Message, UserAttribute},
 };
 use littlefs2::path;
 

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -6,8 +6,7 @@ use crate::{
     error::{Error, Result},
     key,
     store::{self, Store},
-    types::{KeyId, Location},
-    Bytes,
+    types::{Bytes, KeyId, Location},
 };
 
 pub type ClientId = PathBuf;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,8 +11,9 @@ use littlefs2::io::Result as LfsResult;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::client::{CryptoClient as _, FilesystemClient as _};
+use crate::error::Error;
 use crate::types::{consent, reboot, ui, Bytes, Location, PathBuf};
-use crate::{api, block, platform, store, Error};
+use crate::{api, block, platform, store};
 
 pub struct MockRng(ChaCha20);
 
@@ -181,7 +182,7 @@ macro_rules! setup {
         let pc_interface: UserInterface = Default::default();
 
         let platform = $platform::new(rng, store, pc_interface);
-        let mut trussed: crate::Service<$platform> = crate::service::Service::new(platform);
+        let mut trussed: crate::service::Service<$platform> = crate::service::Service::new(platform);
 
         let (test_trussed_requester, test_trussed_responder) = crate::pipe::TRUSSED_INTERCHANGE
             .claim()
@@ -195,7 +196,7 @@ macro_rules! setup {
         trussed.set_seed_if_uninitialized(&$seed);
         let mut $client = {
             pub type TestClient<'a> =
-                crate::ClientImplementation<&'a mut crate::Service<$platform>>;
+                crate::client::ClientImplementation<&'a mut crate::service::Service<$platform>>;
             TestClient::new(test_trussed_requester, &mut trussed, None)
         };
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 #![allow(static_mut_refs)]
+
 use chacha20::ChaCha20;
 
 use crate::types::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -447,8 +447,8 @@ impl TryFrom<ShortData> for Letters {
     }
 }
 
-impl serde::Serialize for Id {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+impl Serialize for Id {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -456,8 +456,8 @@ impl serde::Serialize for Id {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Id {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+impl<'de> Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -470,7 +470,7 @@ impl<'de> serde::Deserialize<'de> for Id {
                 formatter.write_str("16 bytes")
             }
 
-            fn visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E>
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,7 +194,7 @@ impl KeyId {
 // impl_id!(SecretKeyId);
 
 pub mod ui {
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
     // TODO: Consider whether a simple "language" to specify "patterns"
     // makes sense, vs. "semantic" indications with platform-specific implementation
@@ -210,7 +210,7 @@ pub mod ui {
 }
 
 pub mod reboot {
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
     pub enum To {
@@ -220,7 +220,7 @@ pub mod reboot {
 }
 
 pub mod consent {
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
     pub enum Level {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,21 +1,16 @@
 use core::marker::PhantomData;
 use core::ops::Deref;
 
-pub use generic_array::GenericArray;
-
-pub use heapless::{String, Vec};
-
-pub use crate::Bytes;
-
-pub use littlefs2::{
-    driver::Storage as LfsStorage,
-    fs::{DirEntry, Filesystem, Metadata},
-    io::Result as LfsResult,
-    path::{Path, PathBuf},
-};
-
+use heapless::String;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+
+pub use heapless_bytes::Bytes;
+
+pub use littlefs2::{
+    fs::{DirEntry, Metadata},
+    path::{Path, PathBuf},
+};
 
 use crate::config::*;
 use crate::store::filestore::{ReadDirFilesState, ReadDirState};

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,9 +16,6 @@ use crate::config::*;
 use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 use crate::{interrupt::InterruptFlag, key::Secrecy};
 
-pub use crate::client::FutureResult;
-pub use crate::platform::Platform;
-
 /// An empty struct not storing any data.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NoData;

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -16,10 +16,9 @@ use rand_core::SeedableRng as _;
 
 use crate::{
     backend::{BackendId, CoreOnly, Dispatch},
-    client::ClientBuilder,
+    client::{ClientBuilder, ClientImplementation},
     platform::{self, Syscall},
     service::Service,
-    ClientImplementation,
 };
 
 pub use store::{Filesystem, Ram, StoreProvider};

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -6,13 +6,12 @@ use std::{
 };
 
 use generic_array::typenum::{U512, U8};
-use littlefs2::{const_ram_storage, driver::Storage, fs::Allocation};
-
-use crate::{
-    store,
-    store::Store,
-    types::{LfsResult, LfsStorage},
+use littlefs2::{
+    const_ram_storage, driver::Storage, driver::Storage as LfsStorage, fs::Allocation,
+    io::Result as LfsResult,
 };
+
+use crate::{store, store::Store};
 
 pub trait StoreProvider {
     type Store: Store;

--- a/src/virt/ui.rs
+++ b/src/virt/ui.rs
@@ -1,4 +1,7 @@
-use crate::platform::{self, consent::Level, reboot::To, ui::Status};
+use crate::{
+    platform,
+    types::{consent::Level, reboot::To, ui::Status},
+};
 use std::time::{Duration, Instant};
 
 pub struct UserInterface {

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -3,13 +3,12 @@
 use trussed::{
     api::{reply::ReadFile, Reply, Request},
     backend::{self, BackendId},
-    client::FilesystemClient as _,
+    client::{ClientImplementation, FilesystemClient as _},
     error::Error,
     platform,
     service::{Service, ServiceResources},
     types::{CoreContext, Location, Message, PathBuf},
     virt::{self, Ram},
-    ClientImplementation,
 };
 
 type Platform = virt::Platform<Ram>;

--- a/tests/serde_extensions.rs
+++ b/tests/serde_extensions.rs
@@ -28,10 +28,10 @@
 
 use trussed::{
     backend::BackendId,
+    client::ClientImplementation,
     service::Service,
     types::ShortData,
     virt::{self, Ram},
-    ClientImplementation,
 };
 
 use runner::Backends;

--- a/tests/store/mod.rs
+++ b/tests/store/mod.rs
@@ -1,5 +1,6 @@
 use littlefs2::const_ram_storage;
-use trussed::types::{LfsResult, LfsStorage};
+use littlefs2::driver::Storage as LfsStorage;
+use littlefs2::io::Result as LfsResult;
 
 const_ram_storage!(InternalStorage, 8192);
 // const_ram_storage!(InternalStorage, 16384);


### PR DESCRIPTION
Based on the discussion in #155, this PR removes most re-exports of external types and all re-exports of internal types.  The following re-exports are kept:
- `heapless_bytes::Bytes` (only from `types`): crucial part of the client API
- `littlefs2::path::{Path, PathBuf}`: crucial part of the client API
- `littlefs2::fs::{DirEntry, Metadata}`: also part of the client API, though less important
- `cbor_smol::{cbor_deserialize, cbor_serialize_bytes}`: kept for the time being, but should probably replaced with more specific (de-)serialization methods for the data returned or expected by the API at some point

Depends on:
- https://github.com/trussed-dev/trussed/pull/160