### PR TITLE
Service: add (mut) getter for the dispatcher

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -955,6 +955,14 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
                 .unwrap(),
         );
     }
+
+    pub fn dispatch(&self) -> &D {
+        &self.dispatch
+    }
+
+    pub fn dispatch_mut(&mut self) -> &mut D {
+        &mut self.dispatch
+    }
 }
 
 impl<P, D> Syscall for &mut Service<P, D>


### PR DESCRIPTION
This is required so that the startup process can get access to the backends through the dispatcher after having loaded the admin app config (and therefore also having constructed the trussed service).