### PR TITLE
key deletion: delete first the faster volatile storage and test publicc keys first

### DIFF
--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -138,15 +138,15 @@ impl<S: Store> Keystore for ClientKeystore<S> {
 
     // TODO: is this an Oracle?
     fn delete_key(&self, id: &KeyId) -> bool {
-        let secrecies = [key::Secrecy::Secret, key::Secrecy::Public];
+        let secrecies = [key::Secrecy::Public, key::Secrecy::Secret];
 
-        let locations = [Location::Internal, Location::External, Location::Volatile];
+        let locations = [Location::Volatile, Location::Internal, Location::External];
 
-        secrecies.iter().any(|secrecy| {
-            let path = self.key_path(*secrecy, id);
-            locations
-                .iter()
-                .any(|location| store::delete(self.store, *location, &path))
+        locations.iter().any(|location| {
+            secrecies.iter().any(|secrecy| {
+                let path = self.key_path(*secrecy, id);
+                store::delete(self.store, *location, &path)
+            })
         })
     }
 


### PR DESCRIPTION
Most key deletions are for volatile public keys (temporary keys for FIDO pin protocol, PIN keys from trussed-auth etc...). In any cases, persistent keys are more rarely deleted, and volatile is the fastest storage, so it being first is overall a performance improvement.

I think long term (once we have the builder-pattern based syscall implementation maybe?) we should add optional location and secrecy arguments to the syscall. It is rare that the caller would not know the kind of key it is deleting.

Current order is:

- Private
  - Internal
  - External
  - Volatile 
- Public 
  - Internal
  - External
  - Volatile

This PR makes it:

- Volatile
  - Public
  - Private
- External
  - Public
  - Private
- Internal
  - Public
  - Private