### PR TITLE
Remove serde trait implementations for requests and replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nonce` argument to `wrap_key` and `unwrap_key` syscalls.
 - Use nonce as IV for Aes256Cbc mechanism.
 - Updated `cbor-smol` to 0.5.0.
+- Removed `serde::{Deserialize, Serialize}` implementations for the API request
+  and reply structs, `types::{consent::{Error, Level}, reboot::To, StorageAttributes,
+  KeySerialization, SignatureSerialization}`.
 
 ### Fixed
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ littlefs2-core.workspace = true
 postcard.workspace = true
 rand_core.workspace = true
 serde.workspace = true
-
 serde-indexed = "0.1"
 
 [features]

--- a/core/src/api/macros.rs
+++ b/core/src/api/macros.rs
@@ -70,7 +70,7 @@ macro_rules! impl_request {
     )*)
         => {$(
     $(#[$attr])?
-    #[derive(Clone, Eq, PartialEq, Debug, serde_indexed::DeserializeIndexed, serde_indexed::SerializeIndexed)]
+    #[derive(Clone, Eq, PartialEq, Debug)]
     pub struct $request {
         $(
             pub $name: $type,
@@ -109,7 +109,7 @@ macro_rules! impl_reply {
         => {$(
 
     $(#[$attr])?
-    #[derive(Clone, Eq, PartialEq, Debug, serde_indexed::DeserializeIndexed, serde_indexed::SerializeIndexed)]
+    #[derive(Clone, Eq, PartialEq, Debug)]
     pub struct $reply {
         $(
             pub $name: $type,


### PR DESCRIPTION
Implementing Serialize and Deserialize for the request and reply structs leaks implementation details, especially when using serde_indexed.  This patch removes these implementations for the request and reply structs and also for some other types that presumably only had them because they were used in these structs and that are not serialized or deserialized anywhere in the Trussed ecosystem.

Fixes: https://github.com/trussed-dev/trussed/issues/183