### PR TITLE
core: Improve ID hex formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Run tests
-        run: cargo test --features serde-extensions,virt,p384,p521
+        run: cargo test --workspace --features serde-extensions,virt,p384,p521
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
       - name: Check formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   KeySerialization, SignatureSerialization}`.
 - Improved hex formatting of `types::Id`:
   - Removed the unused `Id::hex`.
+  - Deprecated `Id::hex_path` and added `Id::legacy_hex_path` as a replacement.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved hex formatting of `types::Id`:
   - Removed the unused `Id::hex`.
   - Deprecated `Id::hex_path` and added `Id::legacy_hex_path` as a replacement.
+  - Added `Id::clean_hex_path` as an alternative to `Id::legacy_hex_path`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed the unused `Id::hex`.
   - Deprecated `Id::hex_path` and added `Id::legacy_hex_path` as a replacement.
   - Added `Id::clean_hex_path` as an alternative to `Id::legacy_hex_path`.
+  - Changed `Id::hex_clean` to format zero as `"00"`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `serde::{Deserialize, Serialize}` implementations for the API request
   and reply structs, `types::{consent::{Error, Level}, reboot::To, StorageAttributes,
   KeySerialization, SignatureSerialization}`.
+- Improved hex formatting of `types::Id`:
+  - Removed the unused `Id::hex`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://trussed.dev"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-heapless = "0.7"
 heapless-bytes = "0.3"
 littlefs2-core = { version = "0.1", features = ["serde"] }
 postcard = "0.7.0"
@@ -37,7 +36,7 @@ cfg-if = "1.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 flexiber = { version = "0.1.0", features = ["derive", "heapless"] }
 generic-array = "0.14.4"
-heapless = { workspace = true, features = ["serde"] }
+heapless = { version = "0.7", features = ["serde"] }
 hex-literal = "0.4.1"
 nb = "1"
 postcard.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
-heapless.workspace = true
 heapless-bytes.workspace = true
 littlefs2-core.workspace = true
 postcard.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 //! Core types for the [`trussed`][] crate.
 //!

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -419,3 +419,38 @@ impl From<reply::Encrypt> for EncryptedData {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Id;
+
+    #[test]
+    fn test_id_hex_path() {
+        assert_eq!(Id(0).hex_path().as_str(), "00");
+        assert_eq!(Id(1).hex_path().as_str(), "01");
+        assert_eq!(Id(10).hex_path().as_str(), "0a");
+        assert_eq!(Id(16).hex_path().as_str(), "10");
+        assert_eq!(Id(256).hex_path().as_str(), "0100");
+        assert_eq!(Id(4096).hex_path().as_str(), "1000");
+        assert_eq!(Id(1048576).hex_path().as_str(), "1000");
+        assert_eq!(
+            Id(u128::MAX).hex_path().as_str(),
+            "ffffffffffffffffffffffffffffffff"
+        );
+    }
+
+    #[test]
+    fn test_id_hex_clean() {
+        assert_eq!(Id(0).hex_clean().to_string(), "");
+        assert_eq!(Id(1).hex_clean().to_string(), "01");
+        assert_eq!(Id(10).hex_clean().to_string(), "0a");
+        assert_eq!(Id(16).hex_clean().to_string(), "10");
+        assert_eq!(Id(256).hex_clean().to_string(), "0100");
+        assert_eq!(Id(4096).hex_clean().to_string(), "1000");
+        assert_eq!(Id(1048576).hex_clean().to_string(), "100000");
+        assert_eq!(
+            Id(u128::MAX).hex_clean().to_string(),
+            "ffffffffffffffffffffffffffffffff"
+        );
+    }
+}

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -80,8 +80,20 @@ impl Id {
         self.0 < 256
     }
 
-    /// skips leading zeros
+    /// See [`Id::legacy_hex_path`].
+    #[deprecated = "use legacy_hex_path instead"]
     pub fn hex_path(&self) -> PathBuf {
+        self.legacy_hex_path()
+    }
+
+    /// Hex path of this ID without non-trailing zero bytes.
+    ///
+    /// This implementation skips all leading bytes that are zero so that the resulting hex string
+    /// always has an even number of characters and does not start with more than one zero.  For
+    /// compatibility with old Trussed versions, this implementation also skips inner bytes that
+    /// are zero, except for the trailing byte.  This means that for example 4096 and 1048576 both
+    /// are formatted as `"1000"`.
+    pub fn legacy_hex_path(&self) -> PathBuf {
         const HEX_CHARS: &[u8] = b"0123456789abcdef";
         let mut buffer: Bytes<32> = Bytes::new();
         let array = self.0.to_be_bytes();
@@ -427,15 +439,15 @@ mod tests {
 
     #[test]
     fn test_id_hex_path() {
-        assert_eq!(Id(0).hex_path().as_str(), "00");
-        assert_eq!(Id(1).hex_path().as_str(), "01");
-        assert_eq!(Id(10).hex_path().as_str(), "0a");
-        assert_eq!(Id(16).hex_path().as_str(), "10");
-        assert_eq!(Id(256).hex_path().as_str(), "0100");
-        assert_eq!(Id(4096).hex_path().as_str(), "1000");
-        assert_eq!(Id(1048576).hex_path().as_str(), "1000");
+        assert_eq!(Id(0).legacy_hex_path().as_str(), "00");
+        assert_eq!(Id(1).legacy_hex_path().as_str(), "01");
+        assert_eq!(Id(10).legacy_hex_path().as_str(), "0a");
+        assert_eq!(Id(16).legacy_hex_path().as_str(), "10");
+        assert_eq!(Id(256).legacy_hex_path().as_str(), "0100");
+        assert_eq!(Id(4096).legacy_hex_path().as_str(), "1000");
+        assert_eq!(Id(1048576).legacy_hex_path().as_str(), "1000");
         assert_eq!(
-            Id(u128::MAX).hex_path().as_str(),
+            Id(u128::MAX).legacy_hex_path().as_str(),
             "ffffffffffffffffffffffffffffffff"
         );
     }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -81,9 +81,9 @@ impl Id {
     }
 
     /// skips leading zeros
-    pub fn hex(&self) -> Bytes<32> {
+    pub fn hex_path(&self) -> PathBuf {
         const HEX_CHARS: &[u8] = b"0123456789abcdef";
-        let mut buffer = Bytes::new();
+        let mut buffer: Bytes<32> = Bytes::new();
         let array = self.0.to_be_bytes();
 
         for i in 0..array.len() {
@@ -96,11 +96,8 @@ impl Id {
             buffer.push(HEX_CHARS[(array[i] >> 4) as usize]).unwrap();
             buffer.push(HEX_CHARS[(array[i] & 0xf) as usize]).unwrap();
         }
-        buffer
-    }
 
-    pub fn hex_path(&self) -> PathBuf {
-        PathBuf::try_from(self.hex().as_slice()).unwrap()
+        PathBuf::try_from(buffer.as_slice()).unwrap()
     }
 
     /// skips leading zeros

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -145,7 +145,8 @@ impl Id {
     /// Hex representation of this ID without leading zeroes.
     ///
     /// This implementation skips all leading bytes that are zero so that the resulting hex string
-    /// always has an even number of characters and does not start with more than one zero.
+    /// always has an even number of characters and does not start with more than one zero.  0 is
+    /// formatted as `"00"`.
     pub fn hex_clean(&self) -> HexClean {
         HexClean(self.0)
     }
@@ -198,7 +199,8 @@ impl<'de> Deserialize<'de> for Id {
 /// Hex representation of an `u128` without leading zeroes.
 ///
 /// This implementation skips all leading bytes that are zero so that the resulting hex string
-/// always has an even number of characters and does not start with more than one zero.
+/// always has an even number of characters and does not start with more than one zero.  0 is
+/// formatted as `"00"`.
 pub struct HexClean(pub u128);
 
 impl core::fmt::Display for HexClean {
@@ -224,8 +226,9 @@ impl<'a> HexCleanBytes<'a> {
                 upper: true,
             }
         } else {
+            // Format 0 as "00"
             Self {
-                array: &[],
+                array: &[0],
                 upper: true,
             }
         }
@@ -529,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_id_clean_hex_path() {
-        assert_eq!(Id(0).clean_hex_path().as_str(), "");
+        assert_eq!(Id(0).clean_hex_path().as_str(), "00");
         assert_eq!(Id(1).clean_hex_path().as_str(), "01");
         assert_eq!(Id(10).clean_hex_path().as_str(), "0a");
         assert_eq!(Id(16).clean_hex_path().as_str(), "10");
@@ -544,7 +547,7 @@ mod tests {
 
     #[test]
     fn test_id_hex_clean() {
-        assert_eq!(Id(0).hex_clean().to_string(), "");
+        assert_eq!(Id(0).hex_clean().to_string(), "00");
         assert_eq!(Id(1).hex_clean().to_string(), "01");
         assert_eq!(Id(10).hex_clean().to_string(), "0a");
         assert_eq!(Id(16).hex_clean().to_string(), "10");

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -66,7 +66,7 @@ impl<S: Store> ClientCertstore<S> {
         let mut path = PathBuf::new();
         path.push(&self.client_id);
         path.push(path!("x5c"));
-        path.push(&id.hex_path());
+        path.push(&id.legacy_hex_path());
         path
     }
 

--- a/src/store/counterstore.rs
+++ b/src/store/counterstore.rs
@@ -31,7 +31,7 @@ impl<S: Store> ClientCounterstore<S> {
         let mut path = PathBuf::new();
         path.push(&self.client_id);
         path.push(path!("ctr"));
-        path.push(&id.hex_path());
+        path.push(&id.legacy_hex_path());
         path
     }
 

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -86,7 +86,7 @@ impl<S: Store> ClientKeystore<S> {
 
     pub fn key_path(&self, secrecy: key::Secrecy, id: &KeyId) -> PathBuf {
         let mut path = self.key_directory(secrecy);
-        path.push(&id.hex_path());
+        path.push(&id.legacy_hex_path());
         path
     }
 }

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -20,7 +20,7 @@ fn escape_namespace_parent() {
         // first approach: directly escape namespace
         let mut path = PathBuf::from(path!(".."));
         path.push(path!("sec"));
-        path.push(&key.hex_path());
+        path.push(&key.legacy_hex_path());
         assert_eq!(
             try_syscall!(client.read_file(Location::Volatile, path)),
             Err(Error::InvalidPath),
@@ -29,7 +29,7 @@ fn escape_namespace_parent() {
         // second approach: start with subdir, then escape namespace
         let mut path = PathBuf::from(path!("foobar/../.."));
         path.push(path!("sec"));
-        path.push(&key.hex_path());
+        path.push(&key.legacy_hex_path());
         assert_eq!(
             try_syscall!(client.read_file(Location::Volatile, path)),
             Err(Error::InvalidPath),
@@ -38,7 +38,7 @@ fn escape_namespace_parent() {
         // false positive: does not escape namespace but still forbidden
         let mut path = PathBuf::from(path!("foobar/.."));
         path.push(path!("sec"));
-        path.push(&key.hex_path());
+        path.push(&key.legacy_hex_path());
         assert_eq!(
             try_syscall!(client.read_file(Location::Volatile, path)),
             Err(Error::InvalidPath),
@@ -52,7 +52,7 @@ fn escape_namespace_root() {
         let key = syscall!(client.generate_key(Mechanism::P256, StorageAttributes::new())).key;
         let mut path = PathBuf::from(path!("/test"));
         path.push(path!("sec"));
-        path.push(&key.hex_path());
+        path.push(&key.legacy_hex_path());
         assert!(try_syscall!(client.read_file(Location::Volatile, path)).is_err());
     })
 }


### PR DESCRIPTION
This patch tries to improve the confusing situation with ID hex formatting:

- The original `Id::hex` implementation (also used in `Id::hex_path`) skipped inner zero bytes so that different numbers are mapped to the same hex string.  We need to keep this behavior for compatibility.  But to indicate this flaw and avoid usage in new code, this PR removes `Id::hex` and renames `Id::hex_path` to `Id::legacy_hex_path`.  `Id::hex_path` is kept as a deprecated alias for easier migration.
- There already is the `Id::hex_clean` function that correctly formats numbers with inner zero bytes.  This PR also adds `Id::clean_hex_path` that can be used for paths in new code.
- The old `Id::hex_clean` function skipped all zero bytes, including the trailing zero.  As it is currently only used in the `Debug` implementation, this PR changes it to format 0 as `"00"`.
- This PR also adds unit tests for these three functions and removes unnecessary buffer allocations in the implementation.
- As a side effect, this allows us to drop the public `heapless` dependency in `trussed-core`.  Not really important right now, but will be useful once we can upgrade `heapless-bytes`.