### PR TITLE
core: Move api::NotBefore into types

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -31,9 +31,8 @@ use crate::types::Location;
     feature = "filesystem-client"
 ))]
 use crate::types::Message;
-use crate::types::PathBuf;
 #[cfg(feature = "filesystem-client")]
-use crate::types::{DirEntry, UserAttribute};
+use crate::types::{DirEntry, NotBefore, PathBuf, UserAttribute};
 #[cfg(any(feature = "attestation-client", feature = "crypto-client"))]
 use crate::types::{KeyId, Mechanism};
 #[cfg(feature = "crypto-client")]
@@ -50,32 +49,6 @@ mod macros;
 // to the request type in the client.
 //
 // At minimum, we don't want to list the indices (may need proc-macro)
-
-#[derive(Clone, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
-pub enum NotBefore {
-    /// Start iteration at the beginning of the directory
-    None,
-    /// Start iteration at an exact match with the provided filename
-    Filename(PathBuf),
-    /// Start iteration at the first path that is "after" the provided filename
-    FilenamePart(PathBuf),
-}
-
-impl NotBefore {
-    pub fn with_filename(value: Option<PathBuf>) -> Self {
-        match value {
-            None => Self::None,
-            Some(p) => Self::Filename(p),
-        }
-    }
-
-    pub fn with_filename_part(value: Option<PathBuf>) -> Self {
-        match value {
-            None => Self::None,
-            Some(p) => Self::FilenamePart(p),
-        }
-    }
-}
 
 generate_enums! {
 

--- a/core/src/client/filesystem.rs
+++ b/core/src/client/filesystem.rs
@@ -1,7 +1,7 @@
 use super::{ClientResult, PollClient};
 use crate::{
-    api::{reply, request, NotBefore},
-    types::{Location, Message, PathBuf, UserAttribute},
+    api::{reply, request},
+    types::{Location, Message, NotBefore, PathBuf, UserAttribute},
 };
 
 /// Read/Write/Delete files, iterate over directories.

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub use heapless_bytes::Bytes;
 pub use littlefs2_core::{DirEntry, Metadata, PathBuf};
 
+#[cfg(feature = "crypto-client")]
 use crate::api::{reply, request};
 use crate::config::{
     MAX_KEY_MATERIAL_LENGTH, MAX_MEDIUM_DATA_LENGTH, MAX_MESSAGE_LENGTH, MAX_SHORT_DATA_LENGTH,
@@ -383,6 +384,32 @@ impl StorageAttributes {
 impl Default for StorageAttributes {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub enum NotBefore {
+    /// Start iteration at the beginning of the directory
+    None,
+    /// Start iteration at an exact match with the provided filename
+    Filename(PathBuf),
+    /// Start iteration at the first path that is "after" the provided filename
+    FilenamePart(PathBuf),
+}
+
+impl NotBefore {
+    pub fn with_filename(value: Option<PathBuf>) -> Self {
+        match value {
+            None => Self::None,
+            Some(p) => Self::Filename(p),
+        }
+    }
+
+    pub fn with_filename_part(value: Option<PathBuf>) -> Self {
+        match value {
+            None => Self::None,
+            Some(p) => Self::FilenamePart(p),
+        }
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,2 @@
+pub use trussed_core::api::*;
+pub use trussed_core::types::NotBefore;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ generate_macros!();
 
 pub use interchange::Interchange;
 
+pub mod api;
 pub mod backend;
 pub mod client;
 pub mod config;
@@ -51,7 +52,7 @@ pub use error::Error;
 pub use platform::Platform;
 pub use service::Service;
 
-pub use trussed_core::{api, block, error, interrupt, syscall, try_syscall};
+pub use trussed_core::{block, error, interrupt, syscall, try_syscall};
 
 pub use cbor_smol::cbor_deserialize;
 pub use heapless_bytes::Bytes;


### PR DESCRIPTION
All other types that are used in the API are in `types`, so this patch also moves `api::NotBefore` there.