### PR TITLE
core: Make more types non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - As a consequence the type `pipe::TrussedInterchange` becomes a const`pipe::TRUSSED_INTERCHANGE`
 - Updated `littlefs2` to 0.4.0.
 - Made `Request`, `Reply`, `Error`, `Context`, `CoreContext`, `Mechanism`,
-  `ui::Status` non-exhaustive.
+  `KeySerialization`, `SignatureSerialization`, `consent::Error`, `ui::Status` non-exhaustive.
 - Made `postcard_deserialize`, `postcard_serialize` and
   `postcard_serialize_bytes` private.
 - Changed `&PathBuf` to `&Path` where possible.

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -39,6 +39,7 @@ pub use ui::UiClient;
 // to be fair, this is a programmer error,
 // and could also just panic
 #[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
 pub enum ClientError {
     Full,
     Pending,

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -27,6 +27,7 @@ pub mod consent {
     }
 
     #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+    #[non_exhaustive]
     pub enum Error {
         FailedToInterrupt,
         Interrupted,
@@ -417,8 +418,8 @@ impl NotBefore {
 ///
 /// This enum does not provide access to the trait features.  It is only intended for backends to
 /// use in constant assertions to ensure that the correct features are enabled.
-#[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Client {
     AttestationClient,
     CertificateClient,
@@ -611,6 +612,7 @@ impl Mechanism {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum KeySerialization {
     // Asn1Der,
     Cose,
@@ -627,6 +629,7 @@ pub enum KeySerialization {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum SignatureSerialization {
     Asn1Der,
     // Cose,

--- a/src/mechanisms/p256.rs
+++ b/src/mechanisms/p256.rs
@@ -277,6 +277,9 @@ impl Sign for super::P256 {
             SignatureSerialization::Raw => {
                 Signature::from_slice(&signature.to_untagged_bytes()).unwrap()
             }
+            _ => {
+                return Err(Error::InvalidSerializationFormat);
+            }
         };
 
         // return signature
@@ -303,6 +306,9 @@ impl Sign for super::P256Prehashed {
             }
             SignatureSerialization::Raw => {
                 Signature::from_slice(&signature.to_untagged_bytes()).unwrap()
+            }
+            _ => {
+                return Err(Error::InvalidSerializationFormat);
             }
         };
 

--- a/src/mechanisms/p384.rs
+++ b/src/mechanisms/p384.rs
@@ -209,6 +209,9 @@ impl Sign for P384 {
                 Signature::from_slice(der.as_bytes()).unwrap()
             }
             SignatureSerialization::Raw => Signature::from_slice(&signature.to_bytes()).unwrap(),
+            _ => {
+                return Err(Error::InvalidSerializationFormat);
+            }
         };
 
         // return signature
@@ -235,6 +238,9 @@ impl Sign for P384Prehashed {
                 Signature::from_slice(der.as_bytes()).unwrap()
             }
             SignatureSerialization::Raw => Signature::from_slice(&signature.to_bytes()).unwrap(),
+            _ => {
+                return Err(Error::InvalidSerializationFormat);
+            }
         };
 
         // return signature

--- a/src/mechanisms/p521.rs
+++ b/src/mechanisms/p521.rs
@@ -212,6 +212,9 @@ impl Sign for P521 {
                 Signature::from_slice(der.as_bytes()).unwrap()
             }
             SignatureSerialization::Raw => Signature::from_slice(&signature.to_bytes()).unwrap(),
+            _ => {
+                return Err(Error::InvalidSerializationFormat);
+            }
         };
 
         // return signature
@@ -238,6 +241,9 @@ impl Sign for P521Prehashed {
                 Signature::from_slice(der.as_bytes()).unwrap()
             }
             SignatureSerialization::Raw => Signature::from_slice(&signature.to_bytes()).unwrap(),
+            _ => {
+                return Err(Error::InvalidSerializationFormat);
+            }
         };
 
         // return signature


### PR DESCRIPTION
This patch marks more types as non-exhaustive that could be extended in the future and that don’t need to be matched exhaustively:
- `KeySerialization`
- `SignatureSerialization`
- `consent::Error`

The only exhaustive types that could be realistically be extended in the future are now the request and reply structs.  But marking these as non-exhaustive would make it very complex for the backends to implement these syscalls.  We can try to find a solution for that when we think about alternative syscall implementations, e. g. using a builder pattern.