### PR TITLE
Simplify Store trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for non-static channels:
   - Added lifetimes to `ClientImplementation` and `ServiceEndpoints`.
   - Added the `pipe::TrussedChannel` type.
+- Refactored the `Store` trait:
+  - Removed the requirement for a static lifetime.
+  - Removed the `Fs` wrapper type.
+  - Removed the storage types to return `&dyn DynFilesystem` instead.
+  - Removed the `Copy` requirement.
+  - Removed the `unsafe` keyword for the `Store` trait.
 
 ### Fixed
 

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -31,7 +31,7 @@ impl<S: Store> Certstore for ClientCertstore<S> {
         let locations = [Location::Internal, Location::External, Location::Volatile];
         locations
             .iter()
-            .any(|&location| store::delete(self.store, location, &path))
+            .any(|&location| store::delete(&self.store, location, &path))
             .then_some(())
             .ok_or(Error::NoSuchKey)
     }
@@ -41,14 +41,14 @@ impl<S: Store> Certstore for ClientCertstore<S> {
         let locations = [Location::Internal, Location::External, Location::Volatile];
         locations
             .iter()
-            .find_map(|&location| store::read(self.store, location, &path).ok())
+            .find_map(|&location| store::read(&self.store, location, &path).ok())
             .ok_or(Error::NoSuchCertificate)
     }
 
     fn write_certificate(&mut self, location: Location, der: &Message) -> Result<CertId> {
         let id = CertId::new(&mut self.rng);
         let path = self.cert_path(id);
-        store::store(self.store, location, &path, der.as_slice())?;
+        store::store(&self.store, location, &path, der.as_slice())?;
         Ok(id)
     }
 }

--- a/src/store/counterstore.rs
+++ b/src/store/counterstore.rs
@@ -37,14 +37,14 @@ impl<S: Store> ClientCounterstore<S> {
 
     fn read_counter(&mut self, location: Location, id: CounterId) -> Result<Counter> {
         let path = self.counter_path(id);
-        let mut bytes: crate::Bytes<16> = store::read(self.store, location, &path)?;
+        let mut bytes: crate::Bytes<16> = store::read(&self.store, location, &path)?;
         bytes.resize_default(16).ok();
         Ok(u128::from_le_bytes(bytes.as_slice().try_into().unwrap()))
     }
 
     fn write_counter(&mut self, location: Location, id: CounterId, value: u128) -> Result<()> {
         let path = self.counter_path(id);
-        store::store(self.store, location, &path, &value.to_le_bytes())
+        store::store(&self.store, location, &path, &value.to_le_bytes())
     }
 
     fn increment_location(&mut self, location: Location, id: CounterId) -> Result<Counter> {

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -286,7 +286,7 @@ impl<S: Store> ClientFilestore<S> {
                     // the client, and return both the entry and the state
                     .map(|(i, entry)| {
                         // The semantics is that for a non-existent file, we return None (not an error)
-                        let data = store::read(self.store, location, entry.path()).ok();
+                        let data = store::read(&self.store, location, entry.path()).ok();
                         (i, data)
 
                         // the `ok_or` dummy error followed by the `ok` in the next line is because
@@ -352,7 +352,7 @@ impl<S: Store> ClientFilestore<S> {
                     })
                     .map(|(i, entry)| {
                         // The semantics is that for a non-existent file, we return None (not an error)
-                        let data = store::read(self.store, location, entry.path()).ok();
+                        let data = store::read(&self.store, location, entry.path()).ok();
                         (i, data)
                     })
                     // convert Option into Result, again because `read_dir_and_then` expects this
@@ -376,36 +376,36 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     fn read<const N: usize>(&mut self, path: &Path, location: Location) -> Result<Bytes<N>> {
         let path = self.actual_path(path)?;
 
-        store::read(self.store, location, &path)
+        store::read(&self.store, location, &path)
     }
 
     fn write(&mut self, path: &Path, location: Location, data: &[u8]) -> Result<()> {
         let path = self.actual_path(path)?;
-        store::store(self.store, location, &path, data)
+        store::store(&self.store, location, &path, data)
     }
 
     fn exists(&mut self, path: &Path, location: Location) -> bool {
         if let Ok(path) = self.actual_path(path) {
-            store::exists(self.store, location, &path)
+            store::exists(&self.store, location, &path)
         } else {
             false
         }
     }
     fn metadata(&mut self, path: &Path, location: Location) -> Result<Option<Metadata>> {
         let path = self.actual_path(path)?;
-        store::metadata(self.store, location, &path)
+        store::metadata(&self.store, location, &path)
     }
 
     fn rename(&mut self, from: &Path, to: &Path, location: Location) -> Result<()> {
         let from = self.actual_path(from)?;
         let to = self.actual_path(to)?;
-        store::rename(self.store, location, &from, &to)
+        store::rename(&self.store, location, &from, &to)
     }
 
     fn remove_file(&mut self, path: &Path, location: Location) -> Result<()> {
         let path = self.actual_path(path)?;
 
-        match store::delete(self.store, location, &path) {
+        match store::delete(&self.store, location, &path) {
             true => Ok(()),
             false => Err(Error::InternalError),
         }
@@ -414,7 +414,7 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     fn remove_dir(&mut self, path: &Path, location: Location) -> Result<()> {
         let path = self.actual_path(path)?;
 
-        match store::delete(self.store, location, &path) {
+        match store::delete(&self.store, location, &path) {
             true => Ok(()),
             false => Err(Error::InternalError),
         }
@@ -423,7 +423,7 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     fn remove_dir_all(&mut self, path: &Path, location: Location) -> Result<usize> {
         let path = self.actual_path(path)?;
 
-        store::remove_dir_all_where(self.store, location, &path, &|_| true)
+        store::remove_dir_all_where(&self.store, location, &path, &|_| true)
             .map_err(|_| Error::InternalError)
     }
     fn remove_dir_all_where(
@@ -434,7 +434,7 @@ impl<S: Store> Filestore for ClientFilestore<S> {
     ) -> Result<usize> {
         let path = self.actual_path(path)?;
 
-        store::remove_dir_all_where(self.store, location, &path, &predicate)
+        store::remove_dir_all_where(&self.store, location, &path, &predicate)
             .map_err(|_| Error::InternalError)
     }
 

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -118,7 +118,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
 
         let id = self.generate_key_id();
         let path = self.key_path(secrecy, &id);
-        store::store(self.store, location, &path, &key.serialize())?;
+        store::store(&self.store, location, &path, &key.serialize())?;
 
         Ok(id)
     }
@@ -145,7 +145,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
         locations.iter().any(|location| {
             secrecies.iter().any(|secrecy| {
                 let path = self.key_path(*secrecy, id);
-                store::delete(self.store, *location, &path)
+                store::delete(&self.store, *location, &path)
             })
         })
     }
@@ -159,12 +159,12 @@ impl<S: Store> Keystore for ClientKeystore<S> {
     fn delete_all(&self, location: Location) -> Result<usize> {
         let secret_path = self.key_directory(key::Secrecy::Secret);
         let secret_deleted =
-            store::remove_dir_all_where(self.store, location, &secret_path, &|dir_entry| {
+            store::remove_dir_all_where(&self.store, location, &secret_path, &|dir_entry| {
                 dir_entry.file_name().as_ref().len() >= 4
             })?;
         let public_path = self.key_directory(key::Secrecy::Public);
         let public_deleted =
-            store::remove_dir_all_where(self.store, location, &public_path, &|dir_entry| {
+            store::remove_dir_all_where(&self.store, location, &public_path, &|dir_entry| {
                 dir_entry.file_name().as_ref().len() >= 4
             })?;
         Ok(secret_deleted + public_deleted)
@@ -181,7 +181,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
 
         let location = self.location(secrecy, id).ok_or(Error::NoSuchKey)?;
 
-        let bytes: Bytes<{ MAX_KEY_MATERIAL_LENGTH }> = store::read(self.store, location, &path)?;
+        let bytes: Bytes<{ MAX_KEY_MATERIAL_LENGTH }> = store::read(&self.store, location, &path)?;
 
         let key = key::Key::try_deserialize(&bytes)?;
 
@@ -212,7 +212,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
         };
 
         let path = self.key_path(secrecy, id);
-        store::store(self.store, location, &path, &key.serialize())?;
+        store::store(&self.store, location, &path, &key.serialize())?;
 
         Ok(())
     }

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -13,8 +13,9 @@ use crate::{store, store::Store};
 
 pub trait StoreProvider {
     type Store: Store;
+    type Ifs;
 
-    unsafe fn ifs() -> &'static mut <Self::Store as Store>::I;
+    unsafe fn ifs() -> &'static mut Self::Ifs;
 
     unsafe fn store() -> Self::Store;
 
@@ -128,6 +129,7 @@ impl Filesystem {
 
 impl StoreProvider for Filesystem {
     type Store = FilesystemStore;
+    type Ifs = FilesystemStorage;
 
     unsafe fn ifs() -> &'static mut FilesystemStorage {
         (*addr_of_mut!(INTERNAL_FILESYSTEM_STORAGE))
@@ -177,6 +179,7 @@ pub struct Ram {}
 
 impl StoreProvider for Ram {
     type Store = RamStore;
+    type Ifs = InternalStorage;
 
     unsafe fn ifs() -> &'static mut InternalStorage {
         (*addr_of_mut!(INTERNAL_RAM_STORAGE))


### PR DESCRIPTION
This patch simplifies the Store trait by removing the Fs wrapper struct, the Storage types, the static lifetime and the Copy requirement and replaces it with a reference to a DynFilesystem.

This gives runners more options on how to implement the store.

As the Store trait can now easily be implemented in a safe way, this patch also removes the unsafe keyword from the trait definition.