### PR TITLE
Remove DebugDumpStore implementation

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--
+### Changed
+
+- Deprecate `FilesystemClient::debug_dump_store`.  Instead, a debugger should be used to extract the filesystem from a development device.
 
 ## [v0.1.0](https://github.com/trussed-dev/trussed/releases/tag/core-v0.1.0) (2025-01-08)
 

--- a/core/src/client/filesystem.rs
+++ b/core/src/client/filesystem.rs
@@ -6,6 +6,7 @@ use crate::{
 
 /// Read/Write/Delete files, iterate over directories.
 pub trait FilesystemClient: PollClient {
+    #[deprecated]
     fn debug_dump_store(&mut self) -> ClientResult<'_, reply::DebugDumpStore, Self> {
         self.request(request::DebugDumpStore {})
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,4 @@
-use littlefs2_core::{path, DynFilesystem, Path, PathBuf};
+use littlefs2_core::{path, PathBuf};
 use rand_chacha::ChaCha8Rng;
 pub use rand_core::{RngCore, SeedableRng};
 
@@ -10,7 +10,7 @@ pub use crate::key;
 #[cfg(feature = "crypto-client")]
 use crate::mechanisms;
 pub use crate::pipe::ServiceEndpoint;
-use crate::platform::{consent, ui, Platform, Store, UserInterface};
+use crate::platform::{consent, ui, Platform, UserInterface};
 pub use crate::store::{
     self,
     certstore::{Certstore as _, ClientCertstore},
@@ -452,40 +452,9 @@ impl<P: Platform> ServiceResources<P> {
                 Ok(Reply::LocateFile(reply::LocateFile { path }))
             }
 
-            // This is now preferably done using littlefs-fuse (when device is not yet locked),
-            // and should be removed from firmware completely
             #[cfg(feature = "filesystem-client")]
             Request::DebugDumpStore(_request) => {
-                info_now!(":: PERSISTENT");
-                recursively_list(self.platform.store().fs(Location::Internal), path!("/"));
-
-                info_now!(":: VOLATILE");
-                recursively_list(self.platform.store().fs(Location::Volatile), path!("/"));
-
-                fn recursively_list(fs: &dyn DynFilesystem, path: &Path) {
-                    // let fs = store.vfs();
-                    fs.read_dir_and_then(path, &mut |dir| {
-                        for (i, entry) in dir.enumerate() {
-                            let entry = entry.unwrap();
-                            if i < 2 {
-                                // info_now!("skipping {:?}", &entry.path()).ok();
-                                continue;
-                            }
-                            info_now!("{:?} p({:?})", entry.path(), &path);
-                            if entry.file_type().is_dir() {
-                                recursively_list(fs, entry.path());
-                            }
-                            if entry.file_type().is_file() {
-                                let _contents = fs.read::<Bytes<256>>(entry.path()).unwrap();
-                                // info_now!("{} ?= {}", entry.metadata().len(), contents.len()).ok();
-                                // info_now!("{:?}", &contents).ok();
-                            }
-                        }
-                        Ok(())
-                    })
-                    .unwrap();
-                }
-
+                error!("DebugDumpStore is deprecated");
                 Ok(Reply::DebugDumpStore(reply::DebugDumpStore {}))
             }
 


### PR DESCRIPTION
The DebugDumpStore request already does nothing else than printing some static log messages.  To make clear that this syscall should not be used, it is marked as deprecated in trussed-core.  The implementation in trussed is changed to only log an error and return an empty response.

This PR replaces https://github.com/trussed-dev/trussed/pull/111.