### PR TITLE
ci: Check logging code 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
           cargo check --package trussed-core --all-targets
         if: matrix.target == 'x86_64-unknown-linux-gnu'
 
+      - name: Check all targets with default features and logging
+        run: |
+          cargo check --all-targets --features log-all
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+
       - name: Check all features and targets
         run: |
           cargo check --workspace --all-features --all-targets

--- a/src/service.rs
+++ b/src/service.rs
@@ -856,6 +856,13 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
                 };
             }
         }
+
+        #[cfg(all(
+            any(feature = "log-debug", feature = "log-all"),
+            not(feature = "log-none")
+        ))]
+        use crate::store::Store as _;
+
         debug_now!(
             "I/E/V : {}/{}/{} >",
             self.resources


### PR DESCRIPTION
This patch adds a check with `--features log-all` to the CI.  Previously, we only checked with `--all-features` which also sets `log-none` and thus disables logging.

Fixes: https://github.com/trussed-dev/trussed/issues/114