### PR TITLE
Replace heapless dependency with heapless-bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ bitflags = { version = "2.1" }
 cfg-if = "1.0"
 flexiber = { version = "0.2.0", features = ["derive", "heapless"] }
 generic-array = "0.14.4"
-heapless = { version = "0.9", features = ["serde"] }
 hex-literal = "0.4.1"
 nb = "1"
 postcard.workspace = true

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,7 +1,6 @@
 use core::ptr::write_volatile;
 use core::sync::atomic;
 
-use heapless::Vec;
 use serde::{de::Visitor, ser::SerializeMap, Deserialize, Serialize};
 use zeroize::Zeroize;
 
@@ -11,8 +10,8 @@ use crate::{
     Error,
 };
 
-pub type Material = Vec<u8, { MAX_KEY_MATERIAL_LENGTH }>;
-pub type SerializedKeyBytes = Vec<u8, { MAX_SERIALIZED_KEY_LENGTH }>;
+pub type Material = Bytes<MAX_KEY_MATERIAL_LENGTH>;
+pub type SerializedKeyBytes = Bytes<MAX_SERIALIZED_KEY_LENGTH>;
 
 // We don't implement serde to make sure nobody inadvertently still uses it
 // Should we use references here only?
@@ -138,7 +137,7 @@ impl Key {
         Ok(Key {
             flags,
             kind,
-            material: Material::from_slice(material).map_err(|_| Error::InvalidSerializedKey)?,
+            material: Material::try_from(material).map_err(|_| Error::InvalidSerializedKey)?,
         })
     }
 }

--- a/src/mechanisms/p384.rs
+++ b/src/mechanisms/p384.rs
@@ -14,7 +14,7 @@ use crate::{
     key,
     service::MechanismImpl,
     store::keystore::Keystore,
-    types::{KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization},
+    types::{Bytes, KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization},
     Error,
 };
 
@@ -44,9 +44,9 @@ fn load_public_key(keystore: &mut impl Keystore, key_id: &KeyId) -> Result<p384:
     p384::PublicKey::from_sec1_bytes(&compressed_public_key).map_err(|_| Error::InternalError)
 }
 
-fn to_sec1_bytes(public_key: &p384::PublicKey) -> heapless::Vec<u8, { SCALAR_SIZE * 2 + 1 }> {
+fn to_sec1_bytes(public_key: &p384::PublicKey) -> Bytes<{ SCALAR_SIZE * 2 + 1 }> {
     let encoded_point: p384::EncodedPoint = public_key.into();
-    encoded_point.as_bytes().try_into().unwrap()
+    Bytes::try_from(encoded_point.as_bytes()).unwrap()
 }
 
 impl MechanismImpl for P384 {

--- a/src/mechanisms/p521.rs
+++ b/src/mechanisms/p521.rs
@@ -14,7 +14,7 @@ use crate::{
     key,
     service::MechanismImpl,
     store::keystore::Keystore,
-    types::{KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization},
+    types::{Bytes, KeyId, KeySerialization, SerializedKey, Signature, SignatureSerialization},
     Error,
 };
 
@@ -44,9 +44,9 @@ fn load_public_key(keystore: &mut impl Keystore, key_id: &KeyId) -> Result<p521:
     p521::PublicKey::from_sec1_bytes(&compressed_public_key).map_err(|_| Error::InternalError)
 }
 
-fn to_sec1_bytes(public_key: &p521::PublicKey) -> heapless::Vec<u8, { SCALAR_SIZE * 2 + 1 }> {
+fn to_sec1_bytes(public_key: &p521::PublicKey) -> Bytes<{ SCALAR_SIZE * 2 + 1 }> {
     let encoded_point: p521::EncodedPoint = public_key.into();
-    encoded_point.as_bytes().try_into().unwrap()
+    Bytes::try_from(encoded_point.as_bytes()).unwrap()
 }
 
 impl MechanismImpl for P521 {

--- a/src/service/attest.rs
+++ b/src/service/attest.rs
@@ -479,62 +479,6 @@ impl Encodable for Name<'_> {
     }
 }
 
-pub struct ParsedDatetime {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-impl ParsedDatetime {
-    pub fn new(year: u16, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> Option<Self> {
-        let valid = [
-            year >= 2000,
-            year <= 9999,
-            month >= 1,
-            month <= 12,
-            day >= 1,
-            day <= 31,
-            hour <= 23,
-            minute <= 59,
-            second <= 59,
-        ]
-        .iter()
-        .all(|b| *b);
-
-        if valid {
-            Some(Self {
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                second,
-            })
-        } else {
-            None
-        }
-    }
-
-    pub fn to_bytes(&self) -> [u8; 15] {
-        let mut buffer: heapless::Vec<u8, 15> = Default::default();
-        buffer.resize_default(15).unwrap();
-        core::fmt::write(
-            &mut buffer,
-            format_args!(
-                "{}{:02}{:02}{:02}{:02}{:02}Z",
-                self.year, self.month, self.day, self.hour, self.minute, self.second
-            ),
-        )
-        .unwrap();
-        let mut array = [0u8; 15];
-        array.copy_from_slice(&buffer);
-        array
-    }
-}
-
 #[derive(Clone, Copy, Eq, PartialEq)]
 /// Encoded as "YYYYMMDDHHMMSSZ", encoding takes care of truncating YYYY to YY if necessary.
 pub struct Datetime<'l>(&'l [u8]);

--- a/src/store/keystore.rs
+++ b/src/store/keystore.rs
@@ -113,7 +113,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
         let key = key::Key {
             flags: info.flags,
             kind: info.kind,
-            material: key::Material::from_slice(material).unwrap(),
+            material: key::Material::try_from(material).unwrap(),
         };
 
         let id = self.generate_key_id();
@@ -208,7 +208,7 @@ impl<S: Store> Keystore for ClientKeystore<S> {
         let key = key::Key {
             flags: Default::default(),
             kind,
-            material: key::Material::from_slice(material).unwrap(),
+            material: key::Material::try_from(material).unwrap(),
         };
 
         let path = self.key_path(secrecy, id);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,5 @@
 pub use generic_array::GenericArray;
 
-pub use heapless::{String, Vec};
-
 pub use crate::Bytes;
 
 pub use littlefs2_core::{DirEntry, Metadata, Path, PathBuf, Result as LfsResult};


### PR DESCRIPTION
We already use heapless-bytes, so replacing the remaining heapless::Vec usages with heapless_bytes::Bytes makes it easier to reason over the dependencies and eventually update to a new version.

Fixes: https://github.com/trussed-dev/trussed/issues/204