### PR TITLE
Fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,8 +198,7 @@ name = "x255"
 required-features = ["crypto-client", "default-mechanisms", "virt"]
 
 [package.metadata.docs.rs]
-features = ["serde-extensions", "virt"]
-rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [patch.crates-io]
 trussed-core.path = "core"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Core types for the [`trussed`][] crate.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 //! # Trussed
 //!
 //! Trussed® is a minimal, modular way to write cryptographic applications on microcontroller platforms.


### PR DESCRIPTION
This PR removes the outdated `doc_cfg`/`doc_auto_cfg` features for the docs.rs builds and enables all features for the `trussed` documentation.