### PR TITLE
Add test for invalid key size for AEAD mechanisms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,10 @@ test-attestation-cert-ids = []
 test-increased-interchange-size = []
 
 [[test]]
+name = "aead"
+required-features = ["crypto-client", "virt"]
+
+[[test]]
 name = "aes256cbc"
 required-features = ["crypto-client", "default-mechanisms", "virt"]
 

--- a/tests/aead.rs
+++ b/tests/aead.rs
@@ -1,0 +1,25 @@
+use trussed_core::{
+    syscall, try_syscall,
+    types::{Location, Mechanism},
+    CryptoClient, Error,
+};
+
+mod client;
+
+const MECHANISMS: &[Mechanism] = &[
+    #[cfg(feature = "chacha8-poly1305")]
+    Mechanism::Chacha8Poly1305,
+    #[cfg(feature = "aes256-gcm")]
+    Mechanism::Aes256Gcm,
+];
+
+#[test]
+fn test_invalid_key_size() {
+    client::get(|client| {
+        for mechanism in MECHANISMS {
+            let key = syscall!(client.generate_secret_key(16, Location::Volatile)).key;
+            let result = try_syscall!(client.encrypt(*mechanism, key, &[], &[], None));
+            assert_eq!(result, Err(Error::WrongKeyKind));
+        }
+    });
+}


### PR DESCRIPTION
This patch adds a test for the panic on an invalid key size for AEAD mechanisms that was reported by @MG3004 in GHSA-32mp-78p5-q55v and fixed in #224.