### PR TITLE
Fix issues if a virtual client panics

### DIFF
--- a/src/virt.rs
+++ b/src/virt.rs
@@ -8,7 +8,7 @@ mod ui;
 
 use std::{
     iter,
-    sync::mpsc::{self, Receiver, Sender},
+    sync::mpsc::{self, Receiver, Sender, TryRecvError},
     thread,
 };
 
@@ -110,12 +110,12 @@ impl<'a, I: 'static, C> Runner<'a, I, C> {
         I: Send + Sync,
         F: FnOnce() -> R,
     {
-        let (stop_tx, stop_rx) = mpsc::channel();
         let mut service = Service::with_dispatch(platform, dispatch);
         thread::scope(|s| {
+            let (stop_tx, stop_rx) = mpsc::channel();
             s.spawn(move || {
                 let mut eps = self.eps;
-                while stop_rx.try_recv().is_err() {
+                while stop_rx.try_recv() == Err(TryRecvError::Empty) {
                     if self.syscall_rx.try_recv().is_ok() {
                         service.process(&mut eps);
                     }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -10,6 +10,7 @@ use std::{
     iter,
     sync::mpsc::{self, Receiver, Sender, TryRecvError},
     thread,
+    time::Duration,
 };
 
 use rand_chacha::ChaCha8Rng;
@@ -119,6 +120,7 @@ impl<'a, I: 'static, C> Runner<'a, I, C> {
                     if self.syscall_rx.try_recv().is_ok() {
                         service.process(&mut eps);
                     }
+                    thread::sleep(Duration::from_millis(1));
                 }
             });
             let result = f();

--- a/tests/virt.rs
+++ b/tests/virt.rs
@@ -40,3 +40,12 @@ fn test1() {
 fn test2() {
     run_test(2);
 }
+
+#[test]
+#[should_panic]
+fn test_panic() {
+    // panicking tests should return and not run forever
+    virt::with_client(virt::StoreConfig::ram(), "test", |_| {
+        panic!();
+    })
+}


### PR DESCRIPTION
This PR fixes a problem where a panic in a test case using a virtual client would lead to an infinite loop with high CPU usage, e. g. in fido-authenticator (https://github.com/trussed-dev/fido-authenticator/issues/58).