### PR TITLE
Add back doc_cfg feature for docs.rs

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Core types for the [`trussed`][] crate.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! # Trussed
 //!
 //! Trussed® is a minimal, modular way to write cryptographic applications on microcontroller platforms.
@@ -41,7 +42,6 @@ pub mod store;
 pub mod types;
 
 #[cfg(feature = "virt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "virt")))]
 pub mod virt;
 
 pub use api::Reply;


### PR DESCRIPTION
In https://github.com/trussed-dev/trussed/pull/223 I removed both the `doc_auto_cfg` and `doc_cfg` features for docs.rs to fix the build. It looks like I misread the documentation and while `doc_auto_cfg` has been removed, `doc_cfg` is still necessary to document the required features.