### PR TITLE
virt: Simplify UserInterface struct

### DIFF
--- a/src/virt/ui.rs
+++ b/src/virt/ui.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 pub struct UserInterface {
     start_time: Instant,
+    user_presence_level: Level,
     inner: Option<Box<dyn platform::UserInterface + Sync + Send>>,
 }
 
@@ -10,8 +11,13 @@ impl UserInterface {
     pub fn new() -> Self {
         Self {
             start_time: Instant::now(),
+            user_presence_level: Level::Normal,
             inner: None,
         }
+    }
+
+    pub fn set_user_presence_level(&mut self, level: Level) {
+        self.user_presence_level = level;
     }
 
     pub fn set_inner(&mut self, inner: Box<dyn platform::UserInterface + Sync + Send>) {
@@ -34,7 +40,7 @@ impl platform::UserInterface for UserInterface {
         self.inner
             .as_mut()
             .map(|inner| inner.check_user_presence())
-            .unwrap_or(Level::Normal)
+            .unwrap_or(self.user_presence_level)
     }
 
     fn set_status(&mut self, status: Status) {

--- a/src/virt/ui.rs
+++ b/src/virt/ui.rs
@@ -14,8 +14,8 @@ impl UserInterface {
         }
     }
 
-    pub fn set_inner(&mut self, inner: impl Into<Box<dyn platform::UserInterface + Sync + Send>>) {
-        self.inner = Some(inner.into());
+    pub fn set_inner(&mut self, inner: Box<dyn platform::UserInterface + Sync + Send>) {
+        self.inner = Some(inner);
     }
 
     pub fn take_inner(&mut self) -> Option<Box<dyn platform::UserInterface + Sync + Send>> {


### PR DESCRIPTION
This fixes two ergonomic problems with the `virt::UserInterface` struct that we saw in https://github.com/trussed-dev/fido-authenticator/pull/69:
- The `impl Into<...>` wrapper for `UserInterface::set_inner` does not work as expected. Callers have to add type annotations to make it work, so it is easier to just pass the box directly.
- To simulate a different user presence level, users have to implement the full `UserInterface` trait. This PR adds a `UserInterface::set_user_presence_level` method to override the default `Level::Normal`.