### PR TITLE
Remove unconditional Send implementation for Service

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -205,9 +205,6 @@ where
     dispatch: D,
 }
 
-// need to be able to send crypto service to an interrupt handler
-unsafe impl<P: Platform, D: Dispatch> Send for Service<P, D> {}
-
 impl<P: Platform> ServiceResources<P> {
     pub fn certstore(&mut self, ctx: &CoreContext) -> Result<ClientCertstore<P::S>> {
         self.rng()

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -105,8 +105,8 @@ impl<'a, I: 'static, C> Runner<'a, I, C> {
 
     pub fn run<P, D, F, R>(self, platform: P, dispatch: D, f: F) -> R
     where
-        P: platform::Platform,
-        D: Dispatch<Context = C, BackendId = I>,
+        P: platform::Platform + Send,
+        D: Dispatch<Context = C, BackendId = I> + Send,
         C: Send + Sync,
         I: Send + Sync,
         F: FnOnce() -> R,
@@ -160,7 +160,7 @@ impl Platform<'_> {
         self.run_client_with_backends(client_id, CoreOnly, &[], test)
     }
 
-    pub fn run_client_with_backends<R, D: Dispatch>(
+    pub fn run_client_with_backends<R, D: Dispatch + Send>(
         self,
         client_id: &str,
         dispatch: D,
@@ -197,7 +197,7 @@ impl Platform<'_> {
     }
 
     /// Using const generics rather than a `Vec` to allow destructuring in the method
-    pub fn run_clients_with_backends<R, D: Dispatch, const N: usize>(
+    pub fn run_clients_with_backends<R, D: Dispatch + Send, const N: usize>(
         self,
         client_ids: [(&str, &'static [BackendId<D::BackendId>]); N],
         dispatch: D,

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -166,3 +166,5 @@ impl store::Store for Store<'_> {
         self.volatile
     }
 }
+
+unsafe impl Send for Store<'_> {}


### PR DESCRIPTION
The unconditional Send implementation for Service is unsound because we don’t know anything about the platform and dispatch implementations. Instead, runners should add a manual Send implementation for the required structs if necessary. For example, we have to add a manual Send implementation for virt::Store. This is technically not correct but currently the only way to make it work and still better than the implementation for Service.

Fixes: https://github.com/trussed-dev/trussed/issues/211